### PR TITLE
Raise errors if the DAGs in different parties are not the same.

### DIFF
--- a/fed/_private/fed_actor.py
+++ b/fed/_private/fed_actor.py
@@ -91,7 +91,10 @@ class FedActorMethod:
 
 
     def remote(self, *args, **kwargs) -> FedObject:
-        return self._fed_call_holder.internal_remote(*args, **kwargs)
+        import traceback
+        stack = traceback.extract_stack()
+        invoking_frame = stack[len(stack) - 2]
+        return self._fed_call_holder.internal_remote(invoking_frame, *args, **kwargs)
 
 
     def options(self, **options):

--- a/fed/_private/fed_call_holder.py
+++ b/fed/_private/fed_call_holder.py
@@ -64,7 +64,7 @@ class FedCallHolder:
                         fed_task_id,
                         self._node_party,
                         tls_config=None,
-                        invoking_frame=invoking_frame,
+                        invoking_frame=arg.get_invoking_frame(),
                     )
             if (
                 self._options

--- a/fed/api.py
+++ b/fed/api.py
@@ -230,10 +230,14 @@ class FedRemoteFunction:
         return self
 
     def remote(self, *args, **kwargs):
+        import traceback
+        stack = traceback.extract_stack()
+        invoking_frame = stack[len(stack) - 2]
+        
         assert (
             self._node_party is not None
         ), "A fed function should be specified within a party to execute."
-        return self._fed_call_holder.internal_remote(*args, **kwargs)
+        return self._fed_call_holder.internal_remote(invoking_frame, *args, **kwargs)
 
     def _execute_impl(self, args, kwargs):
         return (
@@ -334,6 +338,8 @@ def get(
                         fed_object.get_fed_task_id(),
                         fake_fed_task_id,
                         party_name,
+                        None,
+                        fed_object.get_invoking_frame(),
                     )
         else:
             # This is the code path that the fed_object is not in current party.

--- a/fed/api.py
+++ b/fed/api.py
@@ -233,7 +233,7 @@ class FedRemoteFunction:
         import traceback
         stack = traceback.extract_stack()
         invoking_frame = stack[len(stack) - 2]
-        
+
         assert (
             self._node_party is not None
         ), "A fed function should be specified within a party to execute."
@@ -272,7 +272,10 @@ class FedRemoteClass:
         fed_call_holder = FedCallHolder(
             self._party, fed_actor_handle._execute_impl, self._options
         )
-        fed_call_holder.internal_remote(*cls_args, **cls_kwargs)
+        import traceback
+        stack = traceback.extract_stack()
+        invoking_frame = stack[len(stack) - 2]
+        fed_call_holder.internal_remote(invoking_frame, *cls_args, **cls_kwargs)
         return fed_actor_handle
 
 
@@ -346,7 +349,10 @@ def get(
             # So we should insert a `recv_op` as a barrier to receive the real
             # data from the location party of the fed_object.
             recv_obj = recv(
-                current_party, fed_object.get_fed_task_id(), fake_fed_task_id
+                current_party,
+                fed_object.get_fed_task_id(),
+                fake_fed_task_id,
+                fed_object.get_invoking_frame(),
             )
             ray_refs.append(recv_obj)
 

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -276,9 +276,7 @@ class RecverProxyActor:
             print(invoking_frame)
             print(source_invoking_frame)
             print("============================")
-            assert invoking_frame.filename == source_invoking_frame.filename
-            assert invoking_frame.lineno == source_invoking_frame.lineno, f"source_line_no={source_invoking_frame.lineno}, but curr_line_no={invoking_frame.lineno}"
-            assert invoking_frame.name == source_invoking_frame.name
+            fed_utils.error_if_dag_nodes_are_unaligned(source_invoking_frame, invoking_frame)
             pop_from_two_dim_dict(self._events, upstream_seq_id, curr_seq_id)
 
         # NOTE(qwang): This is used to avoid the conflict with pickle5 in Ray.

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -134,11 +134,6 @@ async def send_data_grpc(
         ) as channel:
             stub = fed_pb2_grpc.GrpcServiceStub(channel)
             data = cloudpickle.dumps(data)
-            # iframe = fed_utils.InvokingFrame(
-            #     invoking_frame.name,
-            #     invoking_frame.lineno,
-            #     invoking_frame.filename,
-            # )
             request = fed_pb2.SendDataRequest(
                 data=data,
                 upstream_seq_id=str(upstream_seq_id),
@@ -155,11 +150,6 @@ async def send_data_grpc(
         async with grpc.aio.insecure_channel(dest, options=grpc_options) as channel:
             stub = fed_pb2_grpc.GrpcServiceStub(channel)
             data = cloudpickle.dumps(data)
-            # iframe = fed_utils.InvokingFrame(
-            #     invoking_frame.name,
-            #     invoking_frame.lineno,
-            #     invoking_frame.filename,
-            # )
             request = fed_pb2.SendDataRequest(
                 data=data,
                 upstream_seq_id=str(upstream_seq_id),

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -134,16 +134,16 @@ async def send_data_grpc(
         ) as channel:
             stub = fed_pb2_grpc.GrpcServiceStub(channel)
             data = cloudpickle.dumps(data)
+            # iframe = fed_utils.InvokingFrame(
+            #     invoking_frame.name,
+            #     invoking_frame.lineno,
+            #     invoking_frame.filename,
+            # )
             request = fed_pb2.SendDataRequest(
                 data=data,
                 upstream_seq_id=str(upstream_seq_id),
                 downstream_seq_id=str(downstream_seq_id),
-                iframe = fed_utils.InvokingFrame(
-                    invoking_frame.name,
-                    invoking_frame.lineno,
-                    invoking_frame.filename,
-                )
-                serialized_invoking_frame=iframe.serialize(),
+                serialized_invoking_frame=invoking_frame,
             )
             # wait for downstream's reply
             response = await stub.SendData(request, timeout=60)
@@ -155,16 +155,16 @@ async def send_data_grpc(
         async with grpc.aio.insecure_channel(dest, options=grpc_options) as channel:
             stub = fed_pb2_grpc.GrpcServiceStub(channel)
             data = cloudpickle.dumps(data)
-            iframe = fed_utils.InvokingFrame(
-                invoking_frame.name,
-                invoking_frame.lineno,
-                invoking_frame.filename,
-            )
+            # iframe = fed_utils.InvokingFrame(
+            #     invoking_frame.name,
+            #     invoking_frame.lineno,
+            #     invoking_frame.filename,
+            # )
             request = fed_pb2.SendDataRequest(
                 data=data,
                 upstream_seq_id=str(upstream_seq_id),
                 downstream_seq_id=str(downstream_seq_id),
-                serialized_invoking_frame=iframe.serialize(),
+                serialized_invoking_frame=invoking_frame,
             )
             # wait for downstream's reply
             response = await stub.SendData(request, timeout=60)
@@ -212,6 +212,11 @@ class SendProxyActor:
             f"[{self._party}] Sending data to seq_id {downstream_seq_id} from {upstream_seq_id}"
         )
         dest_addr = self._cluster[dest_party]['address']
+        iframe = fed_utils.InvokingFrame(
+            invoking_frame.name,
+            invoking_frame.lineno,
+            invoking_frame.filename,
+        )
         response = await send_data_grpc(
             dest=dest_addr,
             data=data,
@@ -220,7 +225,7 @@ class SendProxyActor:
             tls_config=tls_config if tls_config else self._tls_config,
             node_party=node_party,
             retry_policy=self.retry_policy,
-            invoking_frame=invoking_frame,
+            invoking_frame=iframe.serialize(),
         )
         logger.debug(f"Sent. Response is {response}")
         return True  # True indicates it's sent successfully.
@@ -282,9 +287,13 @@ class RecverProxyActor:
         logging.debug(f"[{self._party}] Waited for {curr_seq_id}.")
         with self._lock:
             data, source_invoking_frame = pop_from_two_dim_dict(self._all_data, upstream_seq_id, curr_seq_id)
-            assert invoking_frame.filename == source_invoking_frame.filename
-            assert invoking_frame.lineno == source_invoking_frame.lineno
-            assert invoking_frame.name == source_invoking_frame.name
+            print("============================")
+            print(invoking_frame)
+            print(source_invoking_frame)
+            print("============================")
+            assert invoking_frame.filename == source_invoking_frame.get_file_name()
+            assert invoking_frame.lineno == source_invoking_frame.get_line_no(), f"source_line_no={source_invoking_frame.get_line_no()}, but curr_line_no={invoking_frame.lineno}"
+            assert invoking_frame.name == source_invoking_frame.get_func_name()
             pop_from_two_dim_dict(self._events, upstream_seq_id, curr_seq_id)
 
         # NOTE(qwang): This is used to avoid the conflict with pickle5 in Ray.

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -272,10 +272,6 @@ class RecverProxyActor:
         logging.debug(f"[{self._party}] Waited for {curr_seq_id}.")
         with self._lock:
             data, source_invoking_frame = pop_from_two_dim_dict(self._all_data, upstream_seq_id, curr_seq_id)
-            print("============================")
-            print(invoking_frame)
-            print(source_invoking_frame)
-            print("============================")
             fed_utils.error_if_dag_nodes_are_unaligned(source_invoking_frame, invoking_frame)
             pop_from_two_dim_dict(self._events, upstream_seq_id, curr_seq_id)
 

--- a/fed/fed_object.py
+++ b/fed/fed_object.py
@@ -12,12 +12,15 @@ class FedObject:
         fed_task_id: int,
         object_ref: ObjectRef,
         idx_in_task: int = 0,
+        invoking_frame: list = None,
     ) -> None:
         # The party name to exeute the task which produce this fed object.
         self._node_party = node_party
         self._object_ref = object_ref
         self._fed_task_id = fed_task_id
         self._idx_in_task = idx_in_task
+        assert invoking_frame is not None # TODO(qwang): this should be refined.
+        self._invoking_frame = invoking_frame
 
     def get_ray_object_ref(self):
         return self._object_ref
@@ -27,3 +30,6 @@ class FedObject:
 
     def get_party(self):
         return self._node_party
+
+    def get_invoking_frame(self):
+        return self._invoking_frame

--- a/fed/grpc/fed.proto
+++ b/fed/grpc/fed.proto
@@ -10,7 +10,7 @@ message SendDataRequest {
     bytes data = 1;
     string upstream_seq_id = 2;
     string downstream_seq_id = 3;
-    string serialized_invoking_frame = 4;
+    bytes serialized_invoking_frame = 4;
 };
 
 message SendDataResponse {

--- a/fed/grpc/fed.proto
+++ b/fed/grpc/fed.proto
@@ -10,6 +10,7 @@ message SendDataRequest {
     bytes data = 1;
     string upstream_seq_id = 2;
     string downstream_seq_id = 3;
+    string serialized_invoking_frame = 4;
 };
 
 message SendDataResponse {

--- a/fed/grpc/fed_pb2.py
+++ b/fed/grpc/fed_pb2.py
@@ -14,7 +14,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\tfed.proto\"v\n\x0fSendDataRequest\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\x0c\x12\x17\n\x0fupstream_seq_id\x18\x02 \x01(\t\x12\x19\n\x11\x64ownstream_seq_id\x18\x03 \x01(\t\x12!\n\x19serialized_invoking_frame\x18\x04 \x01(\t\"\"\n\x10SendDataResponse\x12\x0e\n\x06result\x18\x01 \x01(\t2@\n\x0bGrpcService\x12\x31\n\x08SendData\x12\x10.SendDataRequest\x1a\x11.SendDataResponse\"\x00\x42\x03\x80\x01\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\tfed.proto\"v\n\x0fSendDataRequest\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\x0c\x12\x17\n\x0fupstream_seq_id\x18\x02 \x01(\t\x12\x19\n\x11\x64ownstream_seq_id\x18\x03 \x01(\t\x12!\n\x19serialized_invoking_frame\x18\x04 \x01(\x0c\"\"\n\x10SendDataResponse\x12\x0e\n\x06result\x18\x01 \x01(\t2@\n\x0bGrpcService\x12\x31\n\x08SendData\x12\x10.SendDataRequest\x1a\x11.SendDataResponse\"\x00\x42\x03\x80\x01\x01\x62\x06proto3')
 
 
 

--- a/fed/grpc/fed_pb2.py
+++ b/fed/grpc/fed_pb2.py
@@ -3,6 +3,7 @@
 # source: fed.proto
 """Generated protocol buffer code."""
 from google.protobuf import descriptor as _descriptor
+from google.protobuf import descriptor_pool as _descriptor_pool
 from google.protobuf import message as _message
 from google.protobuf import reflection as _reflection
 from google.protobuf import symbol_database as _symbol_database
@@ -13,99 +14,12 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor.FileDescriptor(
-  name='fed.proto',
-  package='',
-  syntax='proto3',
-  serialized_options=b'\200\001\001',
-  create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\tfed.proto\"S\n\x0fSendDataRequest\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\x0c\x12\x17\n\x0fupstream_seq_id\x18\x02 \x01(\t\x12\x19\n\x11\x64ownstream_seq_id\x18\x03 \x01(\t\"\"\n\x10SendDataResponse\x12\x0e\n\x06result\x18\x01 \x01(\t2@\n\x0bGrpcService\x12\x31\n\x08SendData\x12\x10.SendDataRequest\x1a\x11.SendDataResponse\"\x00\x42\x03\x80\x01\x01\x62\x06proto3'
-)
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\tfed.proto\"v\n\x0fSendDataRequest\x12\x0c\n\x04\x64\x61ta\x18\x01 \x01(\x0c\x12\x17\n\x0fupstream_seq_id\x18\x02 \x01(\t\x12\x19\n\x11\x64ownstream_seq_id\x18\x03 \x01(\t\x12!\n\x19serialized_invoking_frame\x18\x04 \x01(\t\"\"\n\x10SendDataResponse\x12\x0e\n\x06result\x18\x01 \x01(\t2@\n\x0bGrpcService\x12\x31\n\x08SendData\x12\x10.SendDataRequest\x1a\x11.SendDataResponse\"\x00\x42\x03\x80\x01\x01\x62\x06proto3')
 
 
 
-
-_SENDDATAREQUEST = _descriptor.Descriptor(
-  name='SendDataRequest',
-  full_name='SendDataRequest',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='data', full_name='SendDataRequest.data', index=0,
-      number=1, type=12, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"",
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='upstream_seq_id', full_name='SendDataRequest.upstream_seq_id', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-    _descriptor.FieldDescriptor(
-      name='downstream_seq_id', full_name='SendDataRequest.downstream_seq_id', index=2,
-      number=3, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=13,
-  serialized_end=96,
-)
-
-
-_SENDDATARESPONSE = _descriptor.Descriptor(
-  name='SendDataResponse',
-  full_name='SendDataResponse',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  create_key=_descriptor._internal_create_key,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='result', full_name='SendDataResponse.result', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=b"".decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto3',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=98,
-  serialized_end=132,
-)
-
-DESCRIPTOR.message_types_by_name['SendDataRequest'] = _SENDDATAREQUEST
-DESCRIPTOR.message_types_by_name['SendDataResponse'] = _SENDDATARESPONSE
-_sym_db.RegisterFileDescriptor(DESCRIPTOR)
-
+_SENDDATAREQUEST = DESCRIPTOR.message_types_by_name['SendDataRequest']
+_SENDDATARESPONSE = DESCRIPTOR.message_types_by_name['SendDataResponse']
 SendDataRequest = _reflection.GeneratedProtocolMessageType('SendDataRequest', (_message.Message,), {
   'DESCRIPTOR' : _SENDDATAREQUEST,
   '__module__' : 'fed_pb2'
@@ -120,32 +34,15 @@ SendDataResponse = _reflection.GeneratedProtocolMessageType('SendDataResponse', 
   })
 _sym_db.RegisterMessage(SendDataResponse)
 
+_GRPCSERVICE = DESCRIPTOR.services_by_name['GrpcService']
+if _descriptor._USE_C_DESCRIPTORS == False:
 
-DESCRIPTOR._options = None
-
-_GRPCSERVICE = _descriptor.ServiceDescriptor(
-  name='GrpcService',
-  full_name='GrpcService',
-  file=DESCRIPTOR,
-  index=0,
-  serialized_options=None,
-  create_key=_descriptor._internal_create_key,
-  serialized_start=134,
-  serialized_end=198,
-  methods=[
-  _descriptor.MethodDescriptor(
-    name='SendData',
-    full_name='GrpcService.SendData',
-    index=0,
-    containing_service=None,
-    input_type=_SENDDATAREQUEST,
-    output_type=_SENDDATARESPONSE,
-    serialized_options=None,
-    create_key=_descriptor._internal_create_key,
-  ),
-])
-_sym_db.RegisterServiceDescriptor(_GRPCSERVICE)
-
-DESCRIPTOR.services_by_name['GrpcService'] = _GRPCSERVICE
-
+  DESCRIPTOR._options = None
+  DESCRIPTOR._serialized_options = b'\200\001\001'
+  _SENDDATAREQUEST._serialized_start=13
+  _SENDDATAREQUEST._serialized_end=131
+  _SENDDATARESPONSE._serialized_start=133
+  _SENDDATARESPONSE._serialized_end=167
+  _GRPCSERVICE._serialized_start=169
+  _GRPCSERVICE._serialized_end=233
 # @@protoc_insertion_point(module_scope)

--- a/fed/utils.py
+++ b/fed/utils.py
@@ -111,30 +111,3 @@ def load_client_certs(tls_config, target_party: str=None):
     client_cert_config = all_clients[target_party]
     return _load_from_cert_config(client_cert_config)
 
-
-class InvokingFrame:
-    def __init__(self, func_name=None, line_no=None, file_name=None) -> None:
-        self._func_name = func_name
-        self._line_no = line_no
-        self._file_name = file_name
-
-
-    def get_func_name(self):
-        return self._func_name
-    
-    def get_line_no(self):
-        return self._line_no
-
-    def get_file_name(self):
-        return self._file_name
-
-    def serialize(self):
-        import cloudpickle
-        li = [self._func_name, self._line_no, self._file_name]
-        return cloudpickle.dumps(li)
-
-    @staticmethod
-    def deserialize(bs):
-        import cloudpickle
-        li = cloudpickle.loads(bs)
-        return InvokingFrame(li[0], li[1], li[2])

--- a/fed/utils.py
+++ b/fed/utils.py
@@ -26,7 +26,7 @@ def resolve_dependencies(current_party, current_fed_task_id, *args, **kwargs):
                     f"[{current_party}] Insert recv_op, arg task id {arg.get_fed_task_id()}, current task id {current_fed_task_id}"
                 )
                 recv_obj = recv(
-                    current_party, arg.get_fed_task_id(), current_fed_task_id, arg.get_invoking_frame
+                    current_party, arg.get_fed_task_id(), current_fed_task_id, arg.get_invoking_frame()
                 )
                 resolved.append(recv_obj)
     if resolved:
@@ -117,7 +117,8 @@ class InvokingFrame:
         self._func_name = func_name
         self._line_no = line_no
         self._file_name = file_name
-    
+
+
     def get_func_name(self):
         return self._func_name
     
@@ -128,6 +129,16 @@ class InvokingFrame:
         return self._file_name
 
     def serialize(self):
+        def __unicode_encode(s):
+            import codecs
+            tp = codecs.unicode_escape_encode(s)
+            return tp[0]
+
+        def __utf8_encode(s):
+            import codecs
+            tp = codecs.utf_8_encode(s)
+            return tp[0]
+
         import cloudpickle
         li = [self._func_name, self._line_no, self._file_name]
         return cloudpickle.dumps(li)
@@ -135,5 +146,15 @@ class InvokingFrame:
     @staticmethod
     def deserialize(bs):
         import cloudpickle
+        def __unicode_decode(self, b):
+            import codecs
+            tp = codecs.unicode_escape_decode(b)
+            return tp[0]
+
+        def __utf8_decode(self, b):
+            import codecs
+            tp = codecs.utf_8_decode(b)
+            return tp[0]
+
         li = cloudpickle.loads(bs)
         return InvokingFrame(li[0], li[1], li[2])

--- a/fed/utils.py
+++ b/fed/utils.py
@@ -129,16 +129,6 @@ class InvokingFrame:
         return self._file_name
 
     def serialize(self):
-        def __unicode_encode(s):
-            import codecs
-            tp = codecs.unicode_escape_encode(s)
-            return tp[0]
-
-        def __utf8_encode(s):
-            import codecs
-            tp = codecs.utf_8_encode(s)
-            return tp[0]
-
         import cloudpickle
         li = [self._func_name, self._line_no, self._file_name]
         return cloudpickle.dumps(li)
@@ -146,15 +136,5 @@ class InvokingFrame:
     @staticmethod
     def deserialize(bs):
         import cloudpickle
-        def __unicode_decode(self, b):
-            import codecs
-            tp = codecs.unicode_escape_decode(b)
-            return tp[0]
-
-        def __utf8_decode(self, b):
-            import codecs
-            tp = codecs.utf_8_decode(b)
-            return tp[0]
-
         li = cloudpickle.loads(bs)
         return InvokingFrame(li[0], li[1], li[2])

--- a/fed/utils.py
+++ b/fed/utils.py
@@ -111,3 +111,14 @@ def load_client_certs(tls_config, target_party: str=None):
     client_cert_config = all_clients[target_party]
     return _load_from_cert_config(client_cert_config)
 
+def error_if_dag_nodes_are_unaligned(source_invoking_frame, curr_invoking_frame):
+            #  assert invoking_frame.filename == source_invoking_frame.filename
+            # assert invoking_frame.lineno == source_invoking_frame.lineno, f"source_line_no={source_invoking_frame.lineno}, but curr_line_no={invoking_frame.lineno}"
+            # assert invoking_frame.name == source_invoking_frame.name
+    if source_invoking_frame.filename != curr_invoking_frame.filename:
+        # TODO(qwang): This is too restrict to use, because the full pathes are usually not the same in different nodes.
+        raise ValueError(f"source filename is {source_invoking_frame.filename}, but current filename is {curr_invoking_frame.filename}")
+    elif source_invoking_frame.lineno != curr_invoking_frame.lineno:
+        raise ValueError(f"source lineno is {source_invoking_frame.lineno}, but current lineno is {curr_invoking_frame.lineno}")
+    elif source_invoking_frame.name != curr_invoking_frame.name:
+        raise ValueError(f"source function name is {source_invoking_frame.name}, but current function name is {curr_invoking_frame.name}")

--- a/fed/utils.py
+++ b/fed/utils.py
@@ -26,7 +26,7 @@ def resolve_dependencies(current_party, current_fed_task_id, *args, **kwargs):
                     f"[{current_party}] Insert recv_op, arg task id {arg.get_fed_task_id()}, current task id {current_fed_task_id}"
                 )
                 recv_obj = recv(
-                    current_party, arg.get_fed_task_id(), current_fed_task_id
+                    current_party, arg.get_fed_task_id(), current_fed_task_id, arg.get_invoking_frame
                 )
                 resolved.append(recv_obj)
     if resolved:
@@ -110,3 +110,30 @@ def load_client_certs(tls_config, target_party: str=None):
     all_clients = tls_config["client_certs"]
     client_cert_config = all_clients[target_party]
     return _load_from_cert_config(client_cert_config)
+
+
+class InvokingFrame:
+    def __init__(self, func_name=None, line_no=None, file_name=None) -> None:
+        self._func_name = func_name
+        self._line_no = line_no
+        self._file_name = file_name
+    
+    def get_func_name(self):
+        return self._func_name
+    
+    def get_line_no(self):
+        return self._line_no
+
+    def get_file_name(self):
+        return self._file_name
+
+    def serialize(self):
+        import cloudpickle
+        li = [self._func_name, self._line_no, self._file_name]
+        return cloudpickle.dumps(li)
+
+    @staticmethod
+    def deserialize(bs):
+        import cloudpickle
+        li = cloudpickle.loads(bs)
+        return InvokingFrame(li[0], li[1], li[2])

--- a/tests/test_unaligned_dag_in_different_parties.py
+++ b/tests/test_unaligned_dag_in_different_parties.py
@@ -3,6 +3,7 @@ import multiprocessing
 import pytest
 import fed
 
+from ray.exceptions import RayTaskError
 
 @fed.remote
 def f1():
@@ -33,17 +34,14 @@ def run(party):
 
     excepted_error = None
     try:
-        print(f"==============A {party}")
         val = fed.get(final_res)
-        print(f"==============B {party}")
         val = fed.get(final_res)
     except Exception as e:
         excepted_error = e
-        print(f"{party}==========================e is {e}")
-    # print(f"[{party}] final res is {val}")
-    # assert val == 100200
-    assert isinstance(excepted_error, ValueError)
-    assert "31" in str(excepted_error) and "28" in str(excepted_error)
+    assert excepted_error is not None
+    if party == "bob":
+        assert "source lineno is 29" in str(excepted_error)
+        assert "current lineno is 32" in str(excepted_error)
     fed.shutdown()
 
 

--- a/tests/test_unaligned_dag_in_different_parties.py
+++ b/tests/test_unaligned_dag_in_different_parties.py
@@ -1,0 +1,53 @@
+import multiprocessing
+
+import pytest
+import fed
+
+
+@fed.remote
+def f1():
+    return 100
+
+@fed.remote
+def f2():
+    return 200
+
+@fed.remote
+def g(val):
+    return val + 100000
+
+def run(party):
+    cluster = {
+        'alice': {'address': '127.0.0.1:11010'},
+        'bob': {'address': '127.0.0.1:11011'},
+    }
+    fed.init(address='local', cluster=cluster, party=party)
+
+    if party == "alice":
+        # WARNING: This is not allowed in real case.
+        res = fed.get(f1.party("alice").remote())
+        print(f"[{party}] res is {res}")
+
+    o = f2.party("alice").remote()
+    final_res = g.party("bob").remote(o)
+    val = fed.get(final_res)
+    print(f"[{party}] final res is {val}")
+    assert val == 100200
+
+    fed.shutdown()
+
+
+def test_p():
+    p_alice = multiprocessing.Process(target=run, args=('alice',))
+    p_bob = multiprocessing.Process(target=run, args=('bob',))
+    p_alice.start()
+    p_bob.start()
+    p_alice.join()
+    p_bob.join()
+    assert p_alice.exitcode == 0 and p_bob.exitcode == 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/tests/test_unaligned_dag_in_different_parties.py
+++ b/tests/test_unaligned_dag_in_different_parties.py
@@ -30,10 +30,20 @@ def run(party):
 
     o = f2.party("alice").remote()
     final_res = g.party("bob").remote(o)
-    val = fed.get(final_res)
-    print(f"[{party}] final res is {val}")
-    assert val == 100200
 
+    excepted_error = None
+    try:
+        print(f"==============A {party}")
+        val = fed.get(final_res)
+        print(f"==============B {party}")
+        val = fed.get(final_res)
+    except Exception as e:
+        excepted_error = e
+        print(f"{party}==========================e is {e}")
+    # print(f"[{party}] final res is {val}")
+    # assert val == 100200
+    assert isinstance(excepted_error, ValueError)
+    assert "31" in str(excepted_error) and "28" in str(excepted_error)
     fed.shutdown()
 
 


### PR DESCRIPTION
Signed-off-by: Qing Wang <kingchin1218@gmail.com>

Due to we always run rayfed on multiple controller mode, the DAG in different parties should be the same, otherwise, the interacting between parties will go wrong.

For example, 
if the DAG in party alice is `f(alice) -> g1(bob) -> h(bob)`,
and  the DAG in party B is `f(alice)->g1(bob)->g2(bob)->h(alice)`,

The h should be inputed from g1, but the g2 output will be sent to h in bob.