### PR TITLE
Remove `party` field from log message.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 # Mac temp files
 .DS_Store
 
+# Vscode
+.vscode/
+

--- a/fed/_private/constants.py
+++ b/fed/_private/constants.py
@@ -23,6 +23,6 @@ RAYFED_TLS_CONFIG = b"__RAYFED_TLS_CONFIG"
 
 RAYFED_CROSS_SILO_SERIALIZING_ALLOWED_LIST = b"__RAYFED_CROSS_SILO_SERIALIZING_ALLOWED_LIST"
 
-RAYFED_LOG_FMT = "%(asctime)s %(levelname)s %(name)s [%(party)s] --  %(message)s"
+RAYFED_LOG_FMT = "%(asctime)s %(levelname)s %(filename)s:%(lineno)s [%(party)s] --  %(message)s"
 
 RAYFED_DATE_FMT = "%Y-%m-%d %H:%M:%S"

--- a/fed/_private/fed_actor.py
+++ b/fed/_private/fed_actor.py
@@ -73,7 +73,7 @@ class FedActorHandle:
         if options and 'num_returns' in options:
             num_returns = options['num_returns']
         logger.debug(
-            f"[{self._party}] Actor method call: {method_name}, num_returns: {num_returns}"
+            f"Actor method call: {method_name}, num_returns: {num_returns}"
         )
         ray_object_ref = self._actor_handle._actor_method_call(
             method_name,

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -65,7 +65,7 @@ class SendDataService(fed_pb2_grpc.GrpcServiceServicer):
         upstream_seq_id = request.upstream_seq_id
         downstream_seq_id = request.downstream_seq_id
         logger.debug(
-            f"[{self._party}] Received a grpc data request from {upstream_seq_id} to {downstream_seq_id}."
+            f"Received a grpc data request from {upstream_seq_id} to {downstream_seq_id}."
         )
 
         with self._lock:
@@ -81,7 +81,7 @@ class SendDataService(fed_pb2_grpc.GrpcServiceServicer):
                 )
         event = get_from_two_dim_dict(self._events, upstream_seq_id, downstream_seq_id)
         event.set()
-        logger.debug(f"[{self._party}] Event set for {upstream_seq_id}")
+        logger.debug(f"Event set for {upstream_seq_id}")
         return fed_pb2.SendDataResponse(result="OK")
 
 
@@ -205,7 +205,7 @@ class SendProxyActor:
             dest_party in self._cluster
         ), f'Failed to find {dest_party} in cluster {self._cluster}.'
         logger.debug(
-            f"[{self._party}] Sending data to seq_id {downstream_seq_id} from {upstream_seq_id}"
+            f"Sending data to seq_id {downstream_seq_id} from {upstream_seq_id}"
         )
         dest_addr = self._cluster[dest_party]['address']
         response = await send_data_grpc(
@@ -261,7 +261,7 @@ class RecverProxyActor:
 
     async def get_data(self, upstream_seq_id, curr_seq_id):
         logger.debug(
-            f"[{self._party}] Getting data for {curr_seq_id} from {upstream_seq_id}"
+            f"Getting data for {curr_seq_id} from {upstream_seq_id}"
         )
         with self._lock:
             if not key_exists_in_two_dim_dict(
@@ -273,7 +273,7 @@ class RecverProxyActor:
 
         curr_event = get_from_two_dim_dict(self._events, upstream_seq_id, curr_seq_id)
         await curr_event.wait()
-        logging.debug(f"[{self._party}] Waited for {curr_seq_id}.")
+        logging.debug(f"Waited for {curr_seq_id}.")
         with self._lock:
             data = pop_from_two_dim_dict(self._all_data, upstream_seq_id, curr_seq_id)
             pop_from_two_dim_dict(self._events, upstream_seq_id, curr_seq_id)

--- a/fed/utils.py
+++ b/fed/utils.py
@@ -32,12 +32,12 @@ def resolve_dependencies(current_party, current_fed_task_id, *args, **kwargs):
             indexes.append(idx)
             if arg.get_party() == current_party:
                 logger.debug(
-                    f"[{current_party}] Insert fed object, arg.party={arg.get_party()}"
+                    f"Insert fed object, arg.party={arg.get_party()}"
                 )
                 resolved.append(arg.get_ray_object_ref())
             else:
                 logger.debug(
-                    f"[{current_party}] Insert recv_op, arg task id {arg.get_fed_task_id()}, current task id {current_fed_task_id}"
+                    f"Insert recv_op, arg task id {arg.get_fed_task_id()}, current task id {current_fed_task_id}"
                 )
                 recv_obj = recv(
                     current_party, arg.get_fed_task_id(), current_fed_task_id


### PR DESCRIPTION
1. party name can be injected to log msg automatically, so remove the explicit writing
2. align log format to RAY
3. ignore .vscode folder