### PR TITLE
[Perf Optimization] Cache fed objects for further using if needed.

### DIFF
--- a/fed/_private/fed_call_holder.py
+++ b/fed/_private/fed_call_holder.py
@@ -70,13 +70,18 @@ class FedCallHolder:
             for arg in flattened_args:
                 # TODO(qwang): We still need to cosider kwargs and a deeply object_ref in this party.
                 if isinstance(arg, FedObject) and arg.get_party() == self._party:
-                    send(
-                        self._node_party,
-                        arg.get_ray_object_ref(),
-                        arg.get_fed_task_id(),
-                        fed_task_id,
-                        self._node_party,
-                    )
+                    if arg.was_sending_or_sent_to_party(self._node_party):
+                        # This object was sending or sent to the target party, so no need to do it again.
+                        continue
+                    else:
+                        arg._mark_is_sending_to_party(self._node_party)
+                        send(
+                            self._node_party,
+                            arg.get_ray_object_ref(),
+                            arg.get_fed_task_id(),
+                            fed_task_id,
+                            self._node_party,
+                        )
             if (
                 self._options
                 and 'num_returns' in self._options

--- a/fed/_private/fed_call_holder.py
+++ b/fed/_private/fed_call_holder.py
@@ -70,7 +70,7 @@ class FedCallHolder:
             for arg in flattened_args:
                 # TODO(qwang): We still need to cosider kwargs and a deeply object_ref in this party.
                 if isinstance(arg, FedObject) and arg.get_party() == self._party:
-                    if arg.was_sending_or_sent_to_party(self._node_party):
+                    if arg._was_sending_or_sent_to_party(self._node_party):
                         # This object was sending or sent to the target party, so no need to do it again.
                         continue
                     else:

--- a/fed/api.py
+++ b/fed/api.py
@@ -370,6 +370,7 @@ def get(
                 received_ray_object_ref = recv(
                     current_party, fed_object.get_fed_task_id(), fake_fed_task_id
                 )
+                fed_object._cache_ray_object_ref(received_ray_object_ref)
             ray_refs.append(received_ray_object_ref)
 
     values = ray.get(ray_refs)

--- a/fed/api.py
+++ b/fed/api.py
@@ -347,7 +347,7 @@ def get(
                 if party_name == current_party:
                     continue
                 else:
-                    if fed_object.was_sending_or_sent_to_party(party_name):
+                    if fed_object._was_sending_or_sent_to_party(party_name):
                         # This object was sending or sent to the target party,
                         # so no need to do it again.
                         continue

--- a/fed/api.py
+++ b/fed/api.py
@@ -347,21 +347,30 @@ def get(
                 if party_name == current_party:
                     continue
                 else:
-                    send(
-                        party_name,
-                        ray_object_ref,
-                        fed_object.get_fed_task_id(),
-                        fake_fed_task_id,
-                        party_name,
-                    )
+                    if fed_object.was_sending_or_sent_to_party(party_name):
+                        # This object was sending or sent to the target party,
+                        # so no need to do it again.
+                        continue
+                    else:
+                        fed_object._mark_is_sending_to_party(party_name)
+                        send(
+                            party_name,
+                            ray_object_ref,
+                            fed_object.get_fed_task_id(),
+                            fake_fed_task_id,
+                            party_name,
+                        )
         else:
             # This is the code path that the fed_object is not in current party.
             # So we should insert a `recv_op` as a barrier to receive the real
             # data from the location party of the fed_object.
-            recv_obj = recv(
-                current_party, fed_object.get_fed_task_id(), fake_fed_task_id
-            )
-            ray_refs.append(recv_obj)
+            if fed_object.get_ray_object_ref() is not None:
+                received_ray_object_ref = fed_object.get_ray_object_ref()
+            else:
+                received_ray_object_ref = recv(
+                    current_party, fed_object.get_fed_task_id(), fake_fed_task_id
+                )
+            ray_refs.append(received_ray_object_ref)
 
     values = ray.get(ray_refs)
     if is_individual_id:

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -260,7 +260,7 @@ class RecverProxyActor:
         return True
 
     async def get_data(self, upstream_seq_id, curr_seq_id):
-        logger.debug(
+        logger.info(
             f"Getting data for {curr_seq_id} from {upstream_seq_id}"
         )
         with self._lock:

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -182,6 +182,7 @@ class SendProxyActor:
         logging_level: str = None,
         retry_policy: Dict = None,
     ):
+        self._stats = {"send_op_count" : 0}
         self._cluster = cluster
         self._party = party
         self._tls_config = tls_config
@@ -201,6 +202,7 @@ class SendProxyActor:
         node_party=None,
         tls_config=None,
     ):
+        self._stats["send_op_count"] += 1
         assert (
             dest_party in self._cluster
         ), f'Failed to find {dest_party} in cluster {self._cluster}.'
@@ -220,6 +222,8 @@ class SendProxyActor:
         logger.debug(f"Sent. Response is {response}")
         return True  # True indicates it's sent successfully.
 
+    async def _get_stats(self):
+        return self._stats
 
 @ray.remote
 class RecverProxyActor:

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -260,7 +260,7 @@ class RecverProxyActor:
         return True
 
     async def get_data(self, upstream_seq_id, curr_seq_id):
-        logger.info(
+        logger.debug(
             f"Getting data for {curr_seq_id} from {upstream_seq_id}"
         )
         with self._lock:

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -231,6 +231,7 @@ class RecverProxyActor:
         logging_level: str = None,
         retry_policy: Dict = None,
     ):
+        self._stats = {"receive_op_count": 0}
         self._listen_addr = listen_addr
         self._party = party
         self._tls_config = tls_config
@@ -260,6 +261,7 @@ class RecverProxyActor:
         return True
 
     async def get_data(self, upstream_seq_id, curr_seq_id):
+        self._stats["receive_op_count"] += 1
         logger.debug(
             f"Getting data for {curr_seq_id} from {upstream_seq_id}"
         )
@@ -283,6 +285,9 @@ class RecverProxyActor:
 
         fed_ser_utils._apply_loads_function_with_whitelist()
         return cloudpickle.loads(data)
+    
+    async def _get_stats(self):
+        return self._stats
 
 
 def start_recv_proxy(

--- a/fed/fed_object.py
+++ b/fed/fed_object.py
@@ -42,19 +42,19 @@ class FedObject:
         self,
         node_party: str,
         fed_task_id: int,
-        object_ref: ObjectRef,
+        ray_object_ref: ObjectRef,
         idx_in_task: int = 0,
     ) -> None:
         # The party name to exeute the task which produce this fed object.
         self._node_party = node_party
-        self._object_ref = object_ref
+        self._ray_object_ref = ray_object_ref
         self._fed_task_id = fed_task_id
         self._idx_in_task = idx_in_task
         self._sending_context = FedObjectSendingContext()
         self._receiving_context = FedObjectReceivingContext()
 
     def get_ray_object_ref(self):
-        return self._object_ref
+        return self._ray_object_ref
 
     def get_fed_task_id(self):
         return f'{self._fed_task_id}#{self._idx_in_task}'
@@ -67,3 +67,6 @@ class FedObject:
     
     def was_sending_or_sent_to_party(self, target_party: str):
         return self._sending_context.was_sending_or_sent_to_party(target_party)
+
+    def _cache_ray_object_ref(self, ray_object_ref):
+        self._ray_object_ref = ray_object_ref

--- a/fed/fed_object.py
+++ b/fed/fed_object.py
@@ -16,6 +16,7 @@ from ray import ObjectRef
 
 
 class FedObjectSendingContext:
+    """The class that's used for holding the all contexts about sending side."""
     def __init__(self) -> None:
         # This field holds the target(downstream) parties that this fed object
         # is sending or sent to.
@@ -30,8 +31,11 @@ class FedObjectSendingContext:
     def was_sending_or_sent_to_party(self, target_party: str):
         return target_party in self._is_sending_or_sent
 
+
 class FedObjectReceivingContext:
+    """The class that's used for holding the all contexts about receiving side."""
     pass
+
 
 class FedObject:
     """The class that represents for a fed object handle for the result
@@ -63,10 +67,13 @@ class FedObject:
         return self._node_party
 
     def _mark_is_sending_to_party(self, target_party: str):
+        """Mark this fed object is sending to the target party."""
         self._sending_context.mark_is_sending_to_party(target_party)
     
-    def was_sending_or_sent_to_party(self, target_party: str):
+    def _was_sending_or_sent_to_party(self, target_party: str):
+        """Query whether this fed object was sending or sent to the target party."""
         return self._sending_context.was_sending_or_sent_to_party(target_party)
 
     def _cache_ray_object_ref(self, ray_object_ref):
+        """Cache the ray object reference for this fed object."""
         self._ray_object_ref = ray_object_ref

--- a/fed/fed_object.py
+++ b/fed/fed_object.py
@@ -15,6 +15,24 @@
 from ray import ObjectRef
 
 
+class FedObjectSendingContext:
+    def __init__(self) -> None:
+        # This field holds the target(downstream) parties that this fed object
+        # is sending or sent to.
+        # The key is the party name and the value is a boolean indicating whether
+        # this object is sending or sent to the party.
+        self._is_sending_or_sent = {}
+
+    def mark_is_sending_to_party(self, target_party: str):
+        assert target_party not in self._is_sending_or_sent
+        self._is_sending_or_sent[target_party] = True
+
+    def was_sending_or_sent_to_party(self, target_party: str):
+        return target_party in self._is_sending_or_sent
+
+class FedObjectReceivingContext:
+    pass
+
 class FedObject:
     """The class that represents for a fed object handle for the result
     of the return value from a fed task.
@@ -32,6 +50,8 @@ class FedObject:
         self._object_ref = object_ref
         self._fed_task_id = fed_task_id
         self._idx_in_task = idx_in_task
+        self._sending_context = FedObjectSendingContext()
+        self._receiving_context = FedObjectReceivingContext()
 
     def get_ray_object_ref(self):
         return self._object_ref
@@ -41,3 +61,9 @@ class FedObject:
 
     def get_party(self):
         return self._node_party
+
+    def _mark_is_sending_to_party(self, target_party: str):
+        self._sending_context.mark_is_sending_to_party(target_party)
+    
+    def was_sending_or_sent_to_party(self, target_party: str):
+        return self._sending_context.was_sending_or_sent_to_party(target_party)

--- a/fed/fed_object.py
+++ b/fed/fed_object.py
@@ -25,7 +25,6 @@ class FedObjectSendingContext:
         self._is_sending_or_sent = {}
 
     def mark_is_sending_to_party(self, target_party: str):
-        assert target_party not in self._is_sending_or_sent
         self._is_sending_or_sent[target_party] = True
 
     def was_sending_or_sent_to_party(self, target_party: str):

--- a/tests/test_cache_fed_objects.py
+++ b/tests/test_cache_fed_objects.py
@@ -38,7 +38,12 @@ def run(party):
     o2 = g.party("bob").remote(o, 2)
 
     a, b, c = fed.get([o, o1, o2])
-
+    assert a == "hello"
+    assert b == "hello1"
+    assert c == "hello2"
+    print(f"[{party}]====a is {a}")
+    print(f"[{party}]====a is {b}")
+    print(f"[{party}]====a is {c}")
     fed.shutdown()
 
 

--- a/tests/test_cache_fed_objects.py
+++ b/tests/test_cache_fed_objects.py
@@ -37,16 +37,17 @@ def run(party):
     o1 = g.party("bob").remote(o, 1)
     o2 = g.party("bob").remote(o, 2)
 
-    import time
-    # time.sleep(1000)
-    
     a, b, c = fed.get([o, o1, o2])
     assert a == "hello"
     assert b == "hello1"
     assert c == "hello2"
-    print(f"[{party}]====a is {a}")
-    print(f"[{party}]====a is {b}")
-    print(f"[{party}]====a is {c}")
+    
+    if party == "bob":
+        import ray
+        proxy_actor = ray.get_actor(f"RecverProxyActor-{party}")
+        stats = ray.get(proxy_actor._get_stats.remote())
+        assert stats["receive_op_count"] == 1
+
     fed.shutdown()
 
 

--- a/tests/test_cache_fed_objects.py
+++ b/tests/test_cache_fed_objects.py
@@ -37,6 +37,9 @@ def run(party):
     o1 = g.party("bob").remote(o, 1)
     o2 = g.party("bob").remote(o, 2)
 
+    import time
+    # time.sleep(1000)
+    
     a, b, c = fed.get([o, o1, o2])
     assert a == "hello"
     assert b == "hello1"

--- a/tests/test_cache_fed_objects.py
+++ b/tests/test_cache_fed_objects.py
@@ -47,11 +47,15 @@ def run(party):
         proxy_actor = ray.get_actor(f"RecverProxyActor-{party}")
         stats = ray.get(proxy_actor._get_stats.remote())
         assert stats["receive_op_count"] == 1
-
+    if party == "alice":
+        import ray
+        proxy_actor = ray.get_actor("SendProxyActor")
+        stats = ray.get(proxy_actor._get_states.remote())
+        assert stats["send_op_count"] == 1
     fed.shutdown()
 
 
-def test_fed_get_in_2_parties():
+def test_cache_fed_object_if_sent():
     p_alice = multiprocessing.Process(target=run, args=('alice',))
     p_bob = multiprocessing.Process(target=run, args=('bob',))
     p_alice.start()

--- a/tests/test_cache_fed_objects.py
+++ b/tests/test_cache_fed_objects.py
@@ -1,0 +1,58 @@
+# Copyright 2022 Ant Group Co., Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import multiprocessing
+
+import pytest
+import fed
+
+
+@fed.remote
+def f():
+    return "hello"
+
+@fed.remote
+def g(x, index):
+    return x + str(index)
+
+def run(party):    
+    cluster = {
+        'alice': {'address': '127.0.0.1:11010'},
+        'bob': {'address': '127.0.0.1:11011'},
+    }
+    fed.init(address='local', cluster=cluster, party=party)
+
+    o = f.party("alice").remote()
+    o1 = g.party("bob").remote(o, 1)
+    o2 = g.party("bob").remote(o, 2)
+
+    a, b, c = fed.get([o, o1, o2])
+
+    fed.shutdown()
+
+
+def test_fed_get_in_2_parties():
+    p_alice = multiprocessing.Process(target=run, args=('alice',))
+    p_bob = multiprocessing.Process(target=run, args=('bob',))
+    p_alice.start()
+    p_bob.start()
+    p_alice.join()
+    p_bob.join()
+    assert p_alice.exitcode == 0 and p_bob.exitcode == 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/tests/test_cache_fed_objects.py
+++ b/tests/test_cache_fed_objects.py
@@ -50,7 +50,7 @@ def run(party):
     if party == "alice":
         import ray
         proxy_actor = ray.get_actor("SendProxyActor")
-        stats = ray.get(proxy_actor._get_states.remote())
+        stats = ray.get(proxy_actor._get_stats.remote())
         assert stats["send_op_count"] == 1
     fed.shutdown()
 


### PR DESCRIPTION
In this PR, we introduce a simple cache for transferring fed objects across parties. 
Before this PR, in the following script, the fed object would be transferred twice from Alice to Bob, while it only be transferred once after this PR.

```python
o = f.party("alice").remote()
o1 = g.party("bob").remote(o, 1) # transferring `o`
o2 = g.party("bob").remote(o, 2) # not transferring `o` any longer from this PR on
```

This is also useful for `fed.get()` a sending/sent fed object.