### PR TITLE
feat: simplify tls config.

### DIFF
--- a/fed/_private/fed_call_holder.py
+++ b/fed/_private/fed_call_holder.py
@@ -40,6 +40,7 @@ class FedCallHolder:
     it's a holder.
 
     """
+
     def __init__(
         self,
         node_party,
@@ -84,11 +85,10 @@ class FedCallHolder:
                     else:
                         arg._mark_is_sending_to_party(self._node_party)
                         send(
-                            self._node_party,
-                            arg.get_ray_object_ref(),
-                            arg.get_fed_task_id(),
-                            fed_task_id,
-                            self._node_party,
+                            dest_party=self._node_party,
+                            data=arg.get_ray_object_ref(),
+                            upstream_seq_id=arg.get_fed_task_id(),
+                            downstream_seq_id=fed_task_id,
                         )
             if (
                 self._options
@@ -96,8 +96,9 @@ class FedCallHolder:
                 and self._options['num_returns'] > 1
             ):
                 num_returns = self._options['num_returns']
-                return [FedObject(
-                    self._node_party, fed_task_id, None, i) for i in range(
-                        num_returns)]
+                return [
+                    FedObject(self._node_party, fed_task_id, None, i)
+                    for i in range(num_returns)
+                ]
             else:
                 return FedObject(self._node_party, fed_task_id, None)

--- a/fed/api.py
+++ b/fed/api.py
@@ -107,6 +107,9 @@ def init(
                     "cert": "bob's server cert",
                     "key": "bob's server cert key",
                 }
+            
+            There is some known problems when there are more than two parties
+            and every party has different root ca, and we're working on it.
         logging_level: optional; the logging level, could be `debug`, `info`,
             `warning`, `error`, `critical`, not case sensititive.
         cross_silo_grpc_retry_policy: a dict descibes the retry policy for

--- a/fed/api.py
+++ b/fed/api.py
@@ -109,7 +109,7 @@ def init(
                 }
             
             There are some known problems when there are more than two parties
-            and every party has different root ca, and we're working on it.
+            and every party has different root ca. We're working on it.
         logging_level: optional; the logging level, could be `debug`, `info`,
             `warning`, `error`, `critical`, not case sensititive.
         cross_silo_grpc_retry_policy: a dict descibes the retry policy for

--- a/fed/api.py
+++ b/fed/api.py
@@ -108,7 +108,7 @@ def init(
                     "key": "bob's server cert key",
                 }
             
-            There is some known problems when there are more than two parties
+            There are some known problems when there are more than two parties
             and every party has different root ca, and we're working on it.
         logging_level: optional; the logging level, could be `debug`, `info`,
             `warning`, `error`, `critical`, not case sensititive.

--- a/tests/test_enable_tls_across_parties.py
+++ b/tests/test_enable_tls_across_parties.py
@@ -37,21 +37,19 @@ def add(x, y):
 
 def _run(party: str):
     cert_dir = os.path.join(
-        os.path.dirname(os.path.abspath(__file__)), "/tmp/rayfed/test-certs/")
-    ca_config = {
-                "ca_cert": os.path.join(cert_dir, "server.crt"),
-                "cert": os.path.join(cert_dir, "server.crt"),
-                "key": os.path.join(cert_dir, "server.key"),
+        os.path.dirname(os.path.abspath(__file__)), "/tmp/rayfed/test-certs/"
+    )
+    cert_config = {
+        "ca_cert": os.path.join(cert_dir, "server.crt"),
+        "cert": os.path.join(cert_dir, "server.crt"),
+        "key": os.path.join(cert_dir, "server.key"),
     }
-    tls_config_alice = {"cert": ca_config, "client_certs": {"bob": ca_config}}
-    tls_config_bob = {"cert": ca_config, "client_certs": {"alice": ca_config}}
-    tls_config = tls_config_alice if party == "alice" else tls_config_bob
 
     cluster = {
         'alice': {'address': '127.0.0.1:11010'},
         'bob': {'address': '127.0.0.1:11011'},
     }
-    fed.init(address='local', cluster=cluster, party=party, tls_config=tls_config)
+    fed.init(address='local', cluster=cluster, party=party, tls_config=cert_config)
 
     my1 = My.party("alice").remote()
     my2 = My.party("bob").remote()
@@ -74,4 +72,5 @@ def test_enable_tls_across_parties():
 
 if __name__ == "__main__":
     import sys
+
     sys.exit(pytest.main(["-sv", __file__]))

--- a/tests/test_transport_proxy_tls.py
+++ b/tests/test_transport_proxy_tls.py
@@ -34,12 +34,11 @@ def test_n_to_1_transport():
     cert_dir = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "/tmp/rayfed/test-certs/"
     )
-    ca_config = {
+    tls_config = {
         "ca_cert": os.path.join(cert_dir, "server.crt"),
         "cert": os.path.join(cert_dir, "server.crt"),
         "key": os.path.join(cert_dir, "server.key"),
     }
-    tls_config = {"cert": ca_config, "client_certs": {"test_node_party": ca_config}}
     internal_kv._internal_kv_put(RAYFED_TLS_CONFIG, cloudpickle.dumps(tls_config))
 
     NUM_DATA = 10

--- a/tests/test_transport_proxy_tls.py
+++ b/tests/test_transport_proxy_tls.py
@@ -60,7 +60,6 @@ def test_n_to_1_transport():
             f"data-{i}",
             i,
             i + 1,
-            "test_node_party",
         )
         sent_objs.append(sent_obj)
         get_obj = recver_proxy_actor.get_data.remote(i, i + 1)


### PR DESCRIPTION
In this PR, we simplify the TLS configuration, and it can fix #56 .

After this PR, TLS configuration should be as the following:
```python
    cert_config = {
        "ca_cert": os.path.join(cert_dir, "server.crt"),
        "cert": os.path.join(cert_dir, "server.crt"),
        "key": os.path.join(cert_dir, "server.key"),
    }
    
    fed.init(cluster=cluster, party="ALICE", tls_config=cert_config)
```

Close #56