### PR TITLE
Be compatible with lower versions of ray.

### DIFF
--- a/.github/workflows/test_on_ray1.13.0.yml
+++ b/.github/workflows/test_on_ray1.13.0.yml
@@ -1,4 +1,4 @@
-name: ubuntu-basic
+name: test-on-ray1.13.0
 
 on:
   push:
@@ -28,7 +28,7 @@ jobs:
             . py3/bin/activate
             which python
             pip install pytest torch cloudpickle cryptography
-            pip install ray==2.0.0
+            pip install ray==1.13.0
 
     - name: Build and test
       run: |

--- a/.github/workflows/test_on_ray2.0.0.yml
+++ b/.github/workflows/test_on_ray2.0.0.yml
@@ -1,0 +1,37 @@
+name: test-on-ray2.0.0
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  run-unit-tests:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    container: docker.io/library/ubuntu:latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install bazel
+      run:  |
+            apt-get update
+            apt-get install -yq wget gcc g++ python3.9 zlib1g-dev zip libuv1.dev
+            apt-get install -yq pip
+
+    - name: Install dependencies
+      run:  |
+            python3 -m pip install virtualenv
+            python3 -m virtualenv -p python3 py3
+            . py3/bin/activate
+            which python
+            pip install pytest torch cloudpickle cryptography
+            pip install ray==2.0.0
+
+    - name: Build and test
+      run: |
+           . py3/bin/activate
+           python3 setup.py install
+           sh test.sh

--- a/fed/_private/compatible_utils.py
+++ b/fed/_private/compatible_utils.py
@@ -29,9 +29,9 @@ def _ray_version_greater_than_2_0_0():
 
 def init_ray(address: str=None, **kwargs):
     if address == "local" and _ray_version_greater_than_2_0_0():
-        ray.init(**kwargs)
-    else:
         ray.init(address=address, **kwargs)
+    else:
+        ray.init(**kwargs)
 
 def get_gcs_address_from_ray_worker():
     try:

--- a/fed/_private/compatible_utils.py
+++ b/fed/_private/compatible_utils.py
@@ -1,12 +1,26 @@
+# Copyright 2022 The RayFed Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import ray
 import fed._private.constants as fed_constants
 
 
-def _compare_ray_version_strings(version1, version2):
+def _compare_version_strings(version1, version2):
     """
-    This utility function compares two Ray version strings and
-    returns True if version1 is greater or they are equal,
-    and False if version2 is greater.
+    This utility function compares two version strings and returns
+    True if version1 is greater, and False if they're equal, and
+    False if version2 is greater.
     """
     v1_list = version1.split('.')
     v2_list = version2.split('.')
@@ -22,18 +36,26 @@ def _compare_ray_version_strings(version1, version2):
     return int(v1_list[i]) > int(v2_list[i])
 
 
-def _ray_version_greater_than_2_0_0():
-    return _compare_ray_version_strings(
-        ray.__version__, fed_constants.RAY_VERSION_2_0_0_STR)
+def _ray_version_less_than_2_0_0():
+    """ Whther the current ray version is less 2.0.0.
+    """
+    return _compare_version_strings(
+        fed_constants.RAY_VERSION_2_0_0_STR, ray.__version__)
 
 
-def init_ray(address: str=None, **kwargs):
-    if address == "local" and _ray_version_greater_than_2_0_0():
-        ray.init(address=address, **kwargs)
-    else:
+def init_ray(address: str = None, **kwargs):
+    """A compatible API to init Ray.
+    """
+    if address == 'local' and _ray_version_less_than_2_0_0():
+        # Ignore the `local` when ray < 2.0.0
         ray.init(**kwargs)
+    else:
+        ray.init(address=address, **kwargs)
+
 
 def get_gcs_address_from_ray_worker():
+    """A compatible API to get the gcs address from the ray worker module.
+    """
     try:
         return ray._private.worker._global_node.gcs_address
     except AttributeError:

--- a/fed/_private/compatible_utils.py
+++ b/fed/_private/compatible_utils.py
@@ -1,0 +1,40 @@
+import ray
+import fed._private.constants as fed_constants
+
+
+def _compare_ray_version_strings(version1, version2):
+    """
+    This utility function compares two Ray version strings and
+    returns True if version1 is greater or they are equal,
+    and False if version2 is greater.
+    """
+    v1_list = version1.split('.')
+    v2_list = version2.split('.')
+    len1 = len(v1_list)
+    len2 = len(v2_list)
+
+    for i in range(min(len1, len2)):
+        if v1_list[i] == v2_list[i]:
+            continue
+        else:
+            break
+
+    return int(v1_list[i]) > int(v2_list[i])
+
+
+def _ray_version_greater_than_2_0_0():
+    return _compare_ray_version_strings(
+        ray.__version__, fed_constants.RAY_VERSION_2_0_0_STR)
+
+
+def init_ray(address: str=None, **kwargs):
+    if address == "local" and _ray_version_greater_than_2_0_0():
+        ray.init(**kwargs)
+    else:
+        ray.init(address=address, **kwargs)
+
+def get_gcs_address_from_ray_worker():
+    try:
+        return ray._private.worker._global_node.gcs_address
+    except AttributeError:
+        return ray.worker._global_node.gcs_address

--- a/fed/_private/constants.py
+++ b/fed/_private/constants.py
@@ -24,3 +24,5 @@ RAYFED_CROSS_SILO_SERIALIZING_ALLOWED_LIST = b"__RAYFED_CROSS_SILO_SERIALIZING_A
 RAYFED_LOG_FMT = "%(asctime)s %(levelname)s %(filename)s:%(lineno)s [%(party)s] --  %(message)s" # noqa
 
 RAYFED_DATE_FMT = "%Y-%m-%d %H:%M:%S"
+
+RAY_VERSION_2_0_0_STR = "2.0.0"

--- a/fed/api.py
+++ b/fed/api.py
@@ -312,7 +312,8 @@ class FedRemoteClass:
 # This is the decorator `@fed.remote`
 def remote(*args, **kwargs):
     def _make_fed_remote(function_or_class, **options):
-        if inspect.isfunction(function_or_class) or fed_utils.is_cython(function_or_class):
+        if (inspect.isfunction(function_or_class)
+                or fed_utils.is_cython(function_or_class)):
             return FedRemoteFunction(function_or_class).options(**options)
 
         if inspect.isclass(function_or_class):

--- a/fed/utils.py
+++ b/fed/utils.py
@@ -138,9 +138,3 @@ def is_cython(obj):
     return check_cython(obj) or (
         hasattr(obj, "__func__") and check_cython(obj.__func__)
     )
-
-def get_gcs_address_from_ray_worker():
-    try:
-        return ray._private.worker._global_node.gcs_address
-    except AttributeError:
-        return ray.worker._global_node.gcs_address

--- a/fed/utils.py
+++ b/fed/utils.py
@@ -122,3 +122,25 @@ def load_cert_config(cert_config):
         cert_chain = file.read()
 
     return ca_cert, private_key, cert_chain
+
+
+def is_cython(obj):
+    """Check if an object is a Cython function or method"""
+
+    # TODO(suo): We could split these into two functions, one for Cython
+    # functions and another for Cython methods.
+    # TODO(suo): There doesn't appear to be a Cython function 'type' we can
+    # check against via isinstance. Please correct me if I'm wrong.
+    def check_cython(x):
+        return type(x).__name__ == "cython_function_or_method"
+
+    # Check if function or method, respectively
+    return check_cython(obj) or (
+        hasattr(obj, "__func__") and check_cython(obj.__func__)
+    )
+
+def get_gcs_address_from_ray_worker():
+    try:
+        return ray._private.worker._global_node.gcs_address
+    except AttributeError:
+        return ray.worker._global_node.gcs_address

--- a/tests/test_transport_proxy.py
+++ b/tests/test_transport_proxy.py
@@ -26,7 +26,7 @@ def test_n_to_1_transport():
     sending data to the target recver proxy, and there also have
     N receivers to `get_data` from Recver proxy at that time.
     """
-    compatible_utils.init(address='local')
+    compatible_utils.init_ray(address='local')
     NUM_DATA = 10
     SERVER_ADDRESS = "127.0.0.1:12344"
     recver_proxy_actor = RecverProxyActor.options(

--- a/tests/test_transport_proxy.py
+++ b/tests/test_transport_proxy.py
@@ -25,7 +25,10 @@ def test_n_to_1_transport():
     sending data to the target recver proxy, and there also have
     N receivers to `get_data` from Recver proxy at that time.
     """
-    ray.init(address='local')
+    if ray.__version__ == "1.13.0":
+        ray.init()
+    else:
+        ray.init(address='local')
     NUM_DATA = 10
     SERVER_ADDRESS = "127.0.0.1:12344"
     recver_proxy_actor = RecverProxyActor.options(

--- a/tests/test_transport_proxy.py
+++ b/tests/test_transport_proxy.py
@@ -18,6 +18,7 @@ import ray
 
 from fed.barriers import RecverProxyActor, send, start_send_proxy
 from fed.cleanup import wait_sending
+import fed._private.compatible_utils as compatible_utils
 
 
 def test_n_to_1_transport():
@@ -25,10 +26,7 @@ def test_n_to_1_transport():
     sending data to the target recver proxy, and there also have
     N receivers to `get_data` from Recver proxy at that time.
     """
-    if ray.__version__ == "1.13.0":
-        ray.init()
-    else:
-        ray.init(address='local')
+    compatible_utils.init(address='local')
     NUM_DATA = 10
     SERVER_ADDRESS = "127.0.0.1:12344"
     recver_proxy_actor = RecverProxyActor.options(

--- a/tests/test_transport_proxy_tls.py
+++ b/tests/test_transport_proxy_tls.py
@@ -18,6 +18,7 @@ import pytest
 import ray
 import cloudpickle
 import ray.experimental.internal_kv as internal_kv
+import fed._private.compatible_utils as compatible_utils
 
 from fed.barriers import RecverProxyActor, send, start_send_proxy
 from fed.cleanup import wait_sending
@@ -29,10 +30,7 @@ def test_n_to_1_transport():
     sending data to the target recver proxy, and there also have
     N receivers to `get_data` from Recver proxy at that time.
     """
-    if ray.__version__ == "1.13.0":
-        ray.init()
-    else:
-        ray.init(address='local')
+    compatible_utils.init(address='local')
 
     cert_dir = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "/tmp/rayfed/test-certs/"

--- a/tests/test_transport_proxy_tls.py
+++ b/tests/test_transport_proxy_tls.py
@@ -29,7 +29,10 @@ def test_n_to_1_transport():
     sending data to the target recver proxy, and there also have
     N receivers to `get_data` from Recver proxy at that time.
     """
-    ray.init(address='local')
+    if ray.__version__ == "1.13.0":
+        ray.init()
+    else:
+        ray.init(address='local')
 
     cert_dir = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "/tmp/rayfed/test-certs/"

--- a/tests/test_transport_proxy_tls.py
+++ b/tests/test_transport_proxy_tls.py
@@ -30,7 +30,7 @@ def test_n_to_1_transport():
     sending data to the target recver proxy, and there also have
     N receivers to `get_data` from Recver proxy at that time.
     """
-    compatible_utils.init(address='local')
+    compatible_utils.init_ray(address='local')
 
     cert_dir = os.path.join(
         os.path.dirname(os.path.abspath(__file__)), "/tmp/rayfed/test-certs/"


### PR DESCRIPTION
We make that RayFed is able to be compatible with the lower versions of Ray.
In this PR, we tested it on Ray1.13.0, that means RayFed is able to be run on Ray1.13.0 officially.