### PR TITLE
docs: correct tls config docstring.

### DIFF
--- a/fed/api.py
+++ b/fed/api.py
@@ -108,9 +108,7 @@ def init(
                     "cert": "bob's server cert",
                     "key": "bob's server cert key",
                 }
-            
-            There are some known problems when there are more than two parties
-            and every party has different root ca. We're working on it.
+
         logging_level: optional; the logging level, could be `debug`, `info`,
             `warning`, `error`, `critical`, not case sensititive.
         cross_silo_grpc_retry_policy: a dict descibes the retry policy for

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ class CleanCommand(setuptools.Command):
 
 setup(
     name='rayfed',
-    version='0.1.0a1',
+    version='0.1.1a0',
     license='Apache 2.0',
     description='A multiple parties joint, distributed execution engine based on Ray,'
                 'to help build your own federated learning frameworks in minutes.',


### PR DESCRIPTION
- Correct tls_config docstring
- Bump to 0.1.1a0 since 0.1.0b1 is shipped already.