### PR TITLE
clear global_context after shutdown

### DIFF
--- a/fed/_private/global_context.py
+++ b/fed/_private/global_context.py
@@ -31,6 +31,7 @@ def get_global_context():
         _global_context = GlobalContext()
     return _global_context
 
+
 def clear_global_context():
     global _global_context
     _global_context = None

--- a/fed/_private/global_context.py
+++ b/fed/_private/global_context.py
@@ -30,3 +30,7 @@ def get_global_context():
     if _global_context is None:
         _global_context = GlobalContext()
     return _global_context
+
+def clear_global_context():
+    global _global_context
+    _global_context = None

--- a/fed/api.py
+++ b/fed/api.py
@@ -26,7 +26,7 @@ import fed.utils as fed_utils
 from fed._private import constants
 from fed._private.fed_actor import FedActorHandle
 from fed._private.fed_call_holder import FedCallHolder
-from fed._private.global_context import get_global_context
+from fed._private.global_context import get_global_context, clear_global_context
 from fed.barriers import ping_others, recv, send, start_recv_proxy, start_send_proxy
 from fed.cleanup import set_exit_on_failure_sending, wait_sending
 from fed.fed_object import FedObject
@@ -176,7 +176,7 @@ def init(
     }
 
     job_config = {
-       constants.KEY_OF_GRPC_METADATA : grpc_metadata,
+        constants.KEY_OF_GRPC_METADATA : grpc_metadata,
     }
     compatible_utils.kv.put(constants.KEY_OF_CLUSTER_CONFIG,
                             cloudpickle.dumps(cluster_config))
@@ -224,8 +224,9 @@ def shutdown():
     compatible_utils.kv.delete(constants.KEY_OF_CLUSTER_CONFIG)
     compatible_utils.kv.delete(constants.KEY_OF_JOB_CONFIG)
     compatible_utils.kv.reset()
+    clear_global_context()
     ray.shutdown()
-    logger.info('Shutdowned ray.')
+    logger.info('Shutdowned rayfed.')
 
 
 def _get_cluster():

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -366,7 +366,7 @@ def start_send_proxy(
     retry_policy=None,
     max_retries=None,
 ):
-    # Create RecevrProxyActor
+    # Create SendProxyActor
     global _SEND_PROXY_ACTOR
     if max_retries is not None:
         _SEND_PROXY_ACTOR = SendProxyActor.options(

--- a/tests/test_reset_context.py
+++ b/tests/test_reset_context.py
@@ -8,17 +8,18 @@ cluster = {
     'bob': {'address': '127.0.0.1:11011'},
 }
 
+
 @fed.remote
 class A:
     def __init__(self, init_val=0) -> None:
         self.value = init_val
-    
+
     def get(self):
         return self.value
 
 
 def run(party):
-    fed.init(        
+    fed.init(   
         address='local',
         cluster=cluster,
         party=party)
@@ -33,7 +34,7 @@ def run(party):
     bob_first_fed_obj_id = bob_fed_obj.get_fed_task_id()
     assert fed.get(bob_fed_obj) == 12
 
-    assert compatible_utils.kv.put("key", "val") == False
+    assert compatible_utils.kv.put("key", "val") is False
     assert compatible_utils.kv.get("key") == b"val"
     fed.shutdown()
     with pytest.raises(AttributeError):
@@ -41,25 +42,25 @@ def run(party):
         # `AttributeError`
         compatible_utils.kv.put("key2", "val2")
 
-    fed.init(        
+    fed.init(
         address='local',
         cluster=cluster,
         party=party)
 
     actor = A.party('alice').remote(10)
     alice_fed_obj = actor.get.remote()
-    alice_second_fed_obj_id = alice_fed_obj.get_fed_task_id()    
+    alice_second_fed_obj_id = alice_fed_obj.get_fed_task_id() 
     assert fed.get(alice_fed_obj) == 10
     assert alice_first_fed_obj_id == alice_second_fed_obj_id
-    
+
     actor = A.party('bob').remote(12)
     bob_fed_obj = actor.get.remote()
     bob_second_fed_obj_id = bob_fed_obj.get_fed_task_id()
     assert fed.get(bob_fed_obj) == 12
     assert bob_first_fed_obj_id == bob_second_fed_obj_id
 
-    assert compatible_utils.kv.get("key") == None
-    assert compatible_utils.kv.put("key", "val") == False
+    assert compatible_utils.kv.get("key") is None
+    assert compatible_utils.kv.put("key", "val") is False
     assert compatible_utils.kv.get("key") == b"val"
 
     fed.shutdown()
@@ -77,6 +78,7 @@ def test_reset_context():
     p_alice.join()
     p_bob.join()
     assert p_alice.exitcode == 0 and p_bob.exitcode == 0
+
 
 if __name__ == "__main__":
     import sys

--- a/tests/test_reset_context.py
+++ b/tests/test_reset_context.py
@@ -1,0 +1,83 @@
+import multiprocessing
+import fed
+import fed._private.compatible_utils as compatible_utils
+import pytest
+
+cluster = {
+    'alice': {'address': '127.0.0.1:11010'},
+    'bob': {'address': '127.0.0.1:11011'},
+}
+
+@fed.remote
+class A:
+    def __init__(self, init_val=0) -> None:
+        self.value = init_val
+    
+    def get(self):
+        return self.value
+
+
+def run(party):
+    fed.init(        
+        address='local',
+        cluster=cluster,
+        party=party)
+
+    actor = A.party('alice').remote(10)
+    alice_fed_obj = actor.get.remote()
+    alice_first_fed_obj_id = alice_fed_obj.get_fed_task_id()
+    assert fed.get(alice_fed_obj) == 10
+
+    actor = A.party('bob').remote(12)
+    bob_fed_obj = actor.get.remote()
+    bob_first_fed_obj_id = bob_fed_obj.get_fed_task_id()
+    assert fed.get(bob_fed_obj) == 12
+
+    assert compatible_utils.kv.put("key", "val") == False
+    assert compatible_utils.kv.get("key") == b"val"
+    fed.shutdown()
+    with pytest.raises(AttributeError):
+        # `internal_kv` should be reset, putting to which should raise
+        # `AttributeError`
+        compatible_utils.kv.put("key2", "val2")
+
+    fed.init(        
+        address='local',
+        cluster=cluster,
+        party=party)
+
+    actor = A.party('alice').remote(10)
+    alice_fed_obj = actor.get.remote()
+    alice_second_fed_obj_id = alice_fed_obj.get_fed_task_id()    
+    assert fed.get(alice_fed_obj) == 10
+    assert alice_first_fed_obj_id == alice_second_fed_obj_id
+    
+    actor = A.party('bob').remote(12)
+    bob_fed_obj = actor.get.remote()
+    bob_second_fed_obj_id = bob_fed_obj.get_fed_task_id()
+    assert fed.get(bob_fed_obj) == 12
+    assert bob_first_fed_obj_id == bob_second_fed_obj_id
+
+    assert compatible_utils.kv.get("key") == None
+    assert compatible_utils.kv.put("key", "val") == False
+    assert compatible_utils.kv.get("key") == b"val"
+
+    fed.shutdown()
+
+
+def test_reset_context():
+    p_alice = multiprocessing.Process(target=run, args=('alice', ))
+    p_bob = multiprocessing.Process(target=run, args=('bob', ))
+    p_alice.start()
+
+    import time
+
+    time.sleep(5)
+    p_bob.start()
+    p_alice.join()
+    p_bob.join()
+    assert p_alice.exitcode == 0 and p_bob.exitcode == 0
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/tests/test_reset_context.py
+++ b/tests/test_reset_context.py
@@ -49,7 +49,7 @@ def run(party):
 
     actor = A.party('alice').remote(10)
     alice_fed_obj = actor.get.remote()
-    alice_second_fed_obj_id = alice_fed_obj.get_fed_task_id() 
+    alice_second_fed_obj_id = alice_fed_obj.get_fed_task_id()
     assert fed.get(alice_fed_obj) == 10
     assert alice_first_fed_obj_id == alice_second_fed_obj_id
 

--- a/tests/test_reset_context.py
+++ b/tests/test_reset_context.py
@@ -19,7 +19,7 @@ class A:
 
 
 def run(party):
-    fed.init(   
+    fed.init(
         address='local',
         cluster=cluster,
         party=party)


### PR DESCRIPTION
The `global_context` incrementally generates the fed task id. It should be reset after calling `fed.shutdown` so that the fed task id can grow from 0 again.