### PR TITLE
ping from ProxyActor & carry grpc meta

### DIFF
--- a/fed/api.py
+++ b/fed/api.py
@@ -219,7 +219,7 @@ def init(
 
     if enable_waiting_for_other_parties_ready:
         # TODO(zhouaihui): can be removed after we have a better retry strategy.
-        ping_others(cluster=cluster, self_party=party, tls_config=tls_config)
+        ping_others(cluster=cluster, self_party=party, max_retries=3600)
 
 
 def shutdown():

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -420,6 +420,7 @@ def recv(party: str, src_party: str, upstream_seq_id, curr_seq_id):
     receiver_proxy = ray.get_actor(f"RecverProxyActor-{party}")
     return receiver_proxy.get_data.remote(src_party, upstream_seq_id, curr_seq_id)
 
+
 def ping_others(cluster: Dict[str, Dict], self_party: str, max_retries=3600):
     """Ping other parties until all are ready or timeout."""
     others = [party for party in cluster if not party == self_party]
@@ -430,7 +431,7 @@ def ping_others(cluster: Dict[str, Dict], self_party: str, max_retries=3600):
             f'Try ping {others} at {tried} attemp, up to {max_retries} attemps.'
         )
         tried += 1
-        _party_ping_obj = {} # {$party_name: $ObjectRef}
+        _party_ping_obj = {}  # {$party_name: $ObjectRef}
         # Batch ping all the other parties
         for other in others:
             _party_ping_obj[other] = send(other, b'data', 'ping', 'ping')
@@ -443,5 +444,6 @@ def ping_others(cluster: Dict[str, Dict], self_party: str, max_retries=3600):
         if others:
             time.sleep(2)
     if others:
-        raise RuntimeError(f"Failed to wait for party: {others} to start, abort executing.")
+        raise RuntimeError(f"Failed to wait for parties: {others} to start, "
+                           "abort `fed.init`.")
     return True

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -420,64 +420,28 @@ def recv(party: str, src_party: str, upstream_seq_id, curr_seq_id):
     receiver_proxy = ray.get_actor(f"RecverProxyActor-{party}")
     return receiver_proxy.get_data.remote(src_party, upstream_seq_id, curr_seq_id)
 
-
-def _grpc_ping(party: str, dest: str, tls_config: Dict) -> bool:
-    try:
-        if tls_config:
-            ca_cert, private_key, cert_chain = fed_utils.load_cert_config(tls_config)
-            credentials = grpc.ssl_channel_credentials(
-                certificate_chain=cert_chain,
-                private_key=private_key,
-                root_certificates=ca_cert,
-            )
-
-            with grpc.secure_channel(
-                dest,
-                credentials,
-            ) as channel:
-                stub = fed_pb2_grpc.GrpcServiceStub(channel)
-                request = fed_pb2.SendDataRequest(
-                    data=b'ping',
-                    upstream_seq_id='ping',
-                    downstream_seq_id='ping',
-                )
-                response = stub.SendData(request)
-        else:
-            with grpc.insecure_channel(dest) as channel:
-                stub = fed_pb2_grpc.GrpcServiceStub(channel)
-                request = fed_pb2.SendDataRequest(
-                    data=b'ping',
-                    upstream_seq_id='ping',
-                    downstream_seq_id='ping',
-                )
-                response = stub.SendData(request)
-        logger.info(
-            f'Succeeded to ping {party} on {dest}, the result: {response.result}.'
-        )
-        return True
-    except Exception as e:
-        logger.info(
-            f'Failed to ping {party} on {dest}, this could be normal, '
-            f'the possible reason is {party} has not yet started.'
-        )
-        logger.debug(f'Ping error: {e}')
-        return False
-
-
-def ping_others(cluster: Dict[str, Dict], self_party: str, tls_config: Dict):
+def ping_others(cluster: Dict[str, Dict], self_party: str, max_retries=3600):
     """Ping other parties until all are ready or timeout."""
     others = [party for party in cluster if not party == self_party]
-    max_retries = 3600
     tried = 0
+
     while tried < max_retries and others:
         logger.info(
             f'Try ping {others} at {tried} attemp, up to {max_retries} attemps.'
         )
         tried += 1
-        others[:] = [
-            other
-            for other in others
-            if not _grpc_ping(other, cluster[other]['address'], tls_config)
+        _party_ping_obj = {} # {$party_name: $ObjectRef}
+        # Batch ping all the other parties
+        for other in others:
+            _party_ping_obj[other] = send(other, b'data', 'ping', 'ping')
+        _, _unready = ray.wait(list(_party_ping_obj.values()), timeout=1)
+
+        # Keep the unready party for the next ping.
+        others = [
+            other for other in others if _party_ping_obj[other] in _unready
         ]
         if others:
             time.sleep(2)
+    if others:
+        raise RuntimeError(f"Failed to wait for party: {others} to start, abort executing.")
+    return True

--- a/tests/test_ping_others.py
+++ b/tests/test_ping_others.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import pytest
 import multiprocessing
 import fed
@@ -28,14 +27,13 @@ cluster = {
 def test_ping_non_started_party():
     def run(party):
         fed.init(address='local', cluster=cluster, party=party)
-        if(party == 'alice'):
+        if (party == 'alice'):
             with pytest.raises(RuntimeError):
                 ping_others(cluster, party, 5)
 
         fed.shutdown()
 
     p_alice = multiprocessing.Process(target=run, args=('alice',))
-    p_bob = multiprocessing.Process(target=run, args=('bob',))
     p_alice.start()
     p_alice.join()
 
@@ -43,9 +41,9 @@ def test_ping_non_started_party():
 def test_ping_started_party():
     def run(party):
         fed.init(address='local', cluster=cluster, party=party)
-        if(party == 'alice'):
+        if (party == 'alice'):
             ping_success = ping_others(cluster, party, 5)
-            assert ping_success == True
+            assert ping_success is True
 
         fed.shutdown()
 
@@ -56,6 +54,7 @@ def test_ping_started_party():
     p_alice.join()
     p_bob.join()
     assert p_alice.exitcode == 0 and p_bob.exitcode == 0
+
 
 if __name__ == "__main__":
     import sys

--- a/tests/test_ping_others.py
+++ b/tests/test_ping_others.py
@@ -1,0 +1,63 @@
+# Copyright 2023 The RayFed Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pytest
+import multiprocessing
+import fed
+from fed.barriers import ping_others
+
+
+cluster = {
+    'alice': {'address': '127.0.0.1:11010'},
+    'bob': {'address': '127.0.0.1:11011'},
+}
+
+
+def test_ping_non_started_party():
+    def run(party):
+        fed.init(address='local', cluster=cluster, party=party)
+        if(party == 'alice'):
+            with pytest.raises(RuntimeError):
+                ping_others(cluster, party, 5)
+
+        fed.shutdown()
+
+    p_alice = multiprocessing.Process(target=run, args=('alice',))
+    p_bob = multiprocessing.Process(target=run, args=('bob',))
+    p_alice.start()
+    p_alice.join()
+
+
+def test_ping_started_party():
+    def run(party):
+        fed.init(address='local', cluster=cluster, party=party)
+        if(party == 'alice'):
+            ping_success = ping_others(cluster, party, 5)
+            assert ping_success == True
+
+        fed.shutdown()
+
+    p_alice = multiprocessing.Process(target=run, args=('alice',))
+    p_bob = multiprocessing.Process(target=run, args=('bob',))
+    p_alice.start()
+    p_bob.start()
+    p_alice.join()
+    p_bob.join()
+    assert p_alice.exitcode == 0 and p_bob.exitcode == 0
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-sv", __file__]))


### PR DESCRIPTION
Ping other parties by the `ProxyActor` instead of the driver, so that it can carry grpc meta and the code can be more easy to maintain.

Close #117 