### PR TITLE
Reset sending queue after `fed.shutdown`

### DIFF
--- a/fed/cleanup.py
+++ b/fed/cleanup.py
@@ -45,8 +45,7 @@ def _check_sending_objs():
         os.kill(os.getpid(), signal.SIGTERM)
 
     global _sending_obj_refs_q
-    if not _sending_obj_refs_q:
-        _sending_obj_refs_q = deque()
+    assert _sending_obj_refs_q is not None
     while True:
         try:
             obj_ref = _sending_obj_refs_q.popleft()
@@ -82,6 +81,10 @@ _monitor_thread = None
 
 
 def _start_check_sending():
+    global _sending_obj_refs_q
+    if not _sending_obj_refs_q:
+        _sending_obj_refs_q = deque()
+
     global _check_send_thread
     if not _check_send_thread:
         _check_send_thread = threading.Thread(target=_check_sending_objs)

--- a/fed/cleanup.py
+++ b/fed/cleanup.py
@@ -106,8 +106,9 @@ def push_to_sending(obj_ref: ray.ObjectRef):
 
 def notify_to_exit():
     global _sending_obj_refs_q
-    _sending_obj_refs_q.append(True)
-    logger.info('Notify check sending thread to exit.')
+    if _sending_obj_refs_q is not None:
+        _sending_obj_refs_q.append(True)
+        logger.info('Notify check sending thread to exit.')
 
 
 def wait_sending():

--- a/fed/cleanup.py
+++ b/fed/cleanup.py
@@ -23,7 +23,7 @@ import ray
 
 logger = logging.getLogger(__name__)
 
-_sending_obj_refs_q = deque()
+_sending_obj_refs_q = None
 
 _check_send_thread = None
 
@@ -45,6 +45,8 @@ def _check_sending_objs():
         os.kill(os.getpid(), signal.SIGTERM)
 
     global _sending_obj_refs_q
+    if not _sending_obj_refs_q:
+        _sending_obj_refs_q = deque()
     while True:
         try:
             obj_ref = _sending_obj_refs_q.popleft()
@@ -66,6 +68,8 @@ def _check_sending_objs():
     logger.info('Check sending thread was exited.')
     global _check_send_thread
     _check_send_thread = None
+    logger.info('Clearing sending queue.')
+    _sending_obj_refs_q = None
 
 
 def _main_thread_monitor():

--- a/fed/cleanup.py
+++ b/fed/cleanup.py
@@ -105,10 +105,9 @@ def push_to_sending(obj_ref: ray.ObjectRef):
 
 
 def notify_to_exit():
-    global _sending_obj_refs_q
-    if _sending_obj_refs_q is not None:
-        _sending_obj_refs_q.append(True)
-        logger.info('Notify check sending thread to exit.')
+    # Sending the termination signal
+    push_to_sending(True)
+    logger.info('Notify check sending thread to exit.')
 
 
 def wait_sending():

--- a/tests/test_repeat_init.py
+++ b/tests/test_repeat_init.py
@@ -16,8 +16,10 @@
 import multiprocessing
 
 import pytest
-
+import time
 import fed
+
+from fed.cleanup import _start_check_sending, push_to_sending
 
 
 @fed.remote
@@ -44,7 +46,16 @@ cluster = {
 
 def run(party):
     def _run():
+        assert fed.cleanup._sending_obj_refs_q is None
         fed.init(address='local', cluster=cluster, party=party)
+        _start_check_sending()
+        time.sleep(0.5)
+        assert fed.cleanup._sending_obj_refs_q is not None
+        push_to_sending(True)
+        # Slightly longer than the queue polling
+        time.sleep(0.6)
+        assert fed.cleanup._sending_obj_refs_q is None
+
         my1 = My.party("alice").remote()
         my2 = My.party("bob").remote()
         o1 = my1.foo.remote(0)
@@ -54,7 +65,9 @@ def run(party):
 
         result = fed.get(o3)
         assert result
+
         fed.shutdown()
+        assert fed.cleanup._sending_obj_refs_q is None
 
     _run()
     _run()


### PR DESCRIPTION
The send queue won't be cleared when shutting down rayfed, the message left in the queue may be read in the next session, i.e. the next time calling `fed.init` , which is one of the reason what happened in this [issue](https://github.com/secretflow/secretflow/issues/529)

Note that this PR couldn't completely fix that problem because there're also flying request after `fed.shutdown`, will open another PR. 