### PR TITLE
Validate address and cluster info.

### DIFF
--- a/fed/api.py
+++ b/fed/api.py
@@ -159,6 +159,7 @@ def init(
     assert party, "Party should be provided."
     assert party in cluster, f"Party {party} is not in cluster {cluster}."
 
+    fed_utils.validate_address(address)
     compatible_utils.init_ray(address=address, **kwargs)
     tls_config = {} if tls_config is None else tls_config
     if tls_config:
@@ -166,7 +167,6 @@ def init(
             'cert' in tls_config and 'key' in tls_config
         ), 'Cert or key are not in tls_config.'
     # A Ray private accessing, should be replaced in public API.
-
     compatible_utils._init_internal_kv()
     compatible_utils.kv.initialize()
 

--- a/fed/api.py
+++ b/fed/api.py
@@ -160,6 +160,8 @@ def init(
     assert party in cluster, f"Party {party} is not in cluster {cluster}."
 
     fed_utils.validate_address(address)
+    fed_utils.validate_cluster_info(cluster)
+
     compatible_utils.init_ray(address=address, **kwargs)
     tls_config = {} if tls_config is None else tls_config
     if tls_config:

--- a/fed/utils.py
+++ b/fed/utils.py
@@ -158,6 +158,7 @@ def dict2tuple(dic):
                     f"skip converting {dic}.")
         return dic
 
+
 def validate_address(address: str) -> None:
     if address is None:
         raise ValueError("The address shouldn't be None.")

--- a/fed/utils.py
+++ b/fed/utils.py
@@ -163,7 +163,7 @@ def validate_address(address: str) -> None:
         raise ValueError("The address shouldn't be None.")
 
     # The specific case for `local` or `localhost`.
-    if address is 'local' or address is 'localhost'
+    if address == 'local' or address == 'localhost':
         return
 
     # Rule 1: "ip:port" format

--- a/fed/utils.py
+++ b/fed/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import re
 
 import fed
 import ray
@@ -156,3 +157,33 @@ def dict2tuple(dic):
         logger.warn(f"Unable to convert type {type(dic)} to tuple"
                     f"skip converting {dic}.")
         return dic
+
+def validate_address(address: str) -> None:
+    if address is None:
+        raise ValueError("The address shouldn't be None.")
+
+    # The specific case for `local` or `localhost`.
+    if address is 'local' or address is 'localhost'
+        return
+
+    # Rule 1: "ip:port" format
+    ip_port_pattern = r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d+$'
+    if re.match(ip_port_pattern, address):
+        return
+
+    # Rule 2: "hostname:port" format
+    hostname_port_pattern = r'^[a-zA-Z0-9.-]+:\d+$'
+    if re.match(hostname_port_pattern, address):
+        return
+
+    # Rule 3: https or http link
+    link_pattern = r'^(https?://).*'
+    if re.match(link_pattern, address):
+        return
+
+    error_msg = ("The address format is invalid. It should be in one of the following formats:\n" # noqa
+                "1. `local` for starting a new cluster, or `localhost` for connecting a local cluster." # noqa
+                "2. 'ip:port' format, where the IP needs to follow the IP address specifications and the port is a number.\n" # noqa
+                "3. 'hostname:port' format, where the hostname is a string and the port is a number.\n" # noqa
+                "4. An HTTPS or HTTP link starting with 'https://' or 'http://'.") # noqa
+    raise ValueError(error_msg)

--- a/fed/utils.py
+++ b/fed/utils.py
@@ -182,8 +182,8 @@ def validate_address(address: str) -> None:
         return
 
     error_msg = ("The address format is invalid. It should be in one of the following formats:\n" # noqa
-                "1. `local` for starting a new cluster, or `localhost` for connecting a local cluster." # noqa
-                "2. 'ip:port' format, where the IP needs to follow the IP address specifications and the port is a number.\n" # noqa
-                "3. 'hostname:port' format, where the hostname is a string and the port is a number.\n" # noqa
-                "4. An HTTPS or HTTP link starting with 'https://' or 'http://'.") # noqa
+                "- `local` for starting a new cluster, or `localhost` for connecting a local cluster.\n" # noqa
+                "- 'ip:port' format, where the IP needs to follow the IP address specifications and the port is a number.\n" # noqa
+                "- 'hostname:port' format, where the hostname is a string and the port is a number.\n" # noqa
+                "- An HTTPS or HTTP link starting with 'https://' or 'http://'.") # noqa
     raise ValueError(error_msg)

--- a/fed/utils.py
+++ b/fed/utils.py
@@ -188,3 +188,11 @@ def validate_address(address: str) -> None:
                 "- 'hostname:port' format, where the hostname is a string and the port is a number.\n" # noqa
                 "- An HTTPS or HTTP link starting with 'https://' or 'http://'.") # noqa
     raise ValueError(error_msg)
+
+
+def validate_cluster_info(cluster: dict):
+    """
+    Validate whether the cluster information is in correct forms.
+    """
+    for _, info in cluster.items():
+        validate_address(info['address'])

--- a/tests/without_ray_tests/test_utils.py
+++ b/tests/without_ray_tests/test_utils.py
@@ -1,0 +1,45 @@
+
+# Copyright 2023 The RayFed Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from typing import Any, Union, List, Tuple, Dict
+import fed
+
+
+@pytest.mark.parametrize("input_address, is_valid_address", [
+    ("192.168.0.1:8080", True),
+    ("sa127032as:80", True),
+    ("https://www.example.com", True),
+    ("http://www.example.com", True),
+    (None, False),
+    ("invalid_string", False),
+    ("http", False),
+    ("example.com", False),
+])
+def test_validate_address(input_address, is_valid_address):
+    if is_valid_address:
+        fed.utils.validate_address(input_address)
+    else:
+        try:
+            fed.utils.validate_address(input_address)
+            assert False
+        except ValueError as e:
+            pass
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/tests/without_ray_tests/test_utils.py
+++ b/tests/without_ray_tests/test_utils.py
@@ -15,7 +15,6 @@
 
 import pytest
 
-from typing import Any, Union, List, Tuple, Dict
 import fed
 
 
@@ -24,6 +23,8 @@ import fed
     ("sa127032as:80", True),
     ("https://www.example.com", True),
     ("http://www.example.com", True),
+    ("local", True),
+    ("localhost", True),
     (None, False),
     ("invalid_string", False),
     ("http", False),
@@ -36,7 +37,7 @@ def test_validate_address(input_address, is_valid_address):
         try:
             fed.utils.validate_address(input_address)
             assert False
-        except ValueError as e:
+        except ValueError as _:
             pass
 
 

--- a/tests/without_ray_tests/test_utils.py
+++ b/tests/without_ray_tests/test_utils.py
@@ -37,8 +37,8 @@ def test_validate_address(input_address, is_valid_address):
         try:
             fed.utils.validate_address(input_address)
             assert False
-        except ValueError as _:
-            pass
+        except Exception as e:
+            assert isinstance(e, ValueError)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is used to validate the address passed into `fed.init()`, leading it following one of the rules:
- `local` for starting a new cluster, or `localhost` for connecting a local cluster.
- 'ip:port' format, where the IP needs to follow the IP address specifications and the port is a number.
- 'hostname:port' format, where the hostname is a string and the port is a number.
- An HTTPS or HTTP link starting with 'https://' or 'http://'.