### PR TITLE
Setup ProxyActor Config [1/N]

### DIFF
--- a/fed/api.py
+++ b/fed/api.py
@@ -41,8 +41,9 @@ def init(
     tls_config: Dict = None,
     logging_level: str = 'info',
     cross_silo_grpc_retry_policy: Dict = None,
-    cross_silo_send_max_retries: int = None,
     cross_silo_serializing_allowed_list: Dict = None,
+    cross_silo_send_options: Dict = None,
+    cross_silo_recv_options: Dict = None,
     exit_on_failure_cross_silo_sending: bool = False,
     cross_silo_messages_max_size_in_bytes: int = None,
     cross_silo_timeout_in_seconds: int = 60,
@@ -127,7 +128,6 @@ def init(
                         "UNAVAILABLE"
                     ]
                 }
-        cross_silo_send_max_retries: the max retries for sending data cross silo.
         cross_silo_serializing_allowed_list: The package or class list allowed for
             serializing(deserializating) cross silos. It's used for avoiding pickle
             deserializing execution attack when crossing solis.
@@ -208,6 +208,7 @@ def init(
         logging_level=logging_level,
         tls_config=tls_config,
         retry_policy=cross_silo_grpc_retry_policy,
+        actor_options=cross_silo_recv_options
     )
     start_send_proxy(
         cluster=cluster,
@@ -215,7 +216,7 @@ def init(
         logging_level=logging_level,
         tls_config=tls_config,
         retry_policy=cross_silo_grpc_retry_policy,
-        max_retries=cross_silo_send_max_retries,
+        actor_options=cross_silo_send_options
     )
 
     if enable_waiting_for_other_parties_ready:

--- a/fed/api.py
+++ b/fed/api.py
@@ -42,8 +42,8 @@ def init(
     logging_level: str = 'info',
     cross_silo_grpc_retry_policy: Dict = None,
     cross_silo_serializing_allowed_list: Dict = None,
-    cross_silo_send_options: Dict = None,
-    cross_silo_recv_options: Dict = None,
+    cross_silo_send_resource_label: Dict = None,
+    cross_silo_recv_resource_label: Dict = None,
     exit_on_failure_cross_silo_sending: bool = False,
     cross_silo_messages_max_size_in_bytes: int = None,
     cross_silo_timeout_in_seconds: int = 60,
@@ -131,14 +131,14 @@ def init(
         cross_silo_serializing_allowed_list: The package or class list allowed for
             serializing(deserializating) cross silos. It's used for avoiding pickle
             deserializing execution attack when crossing solis.
-        cross_silo_send_options: A subset of Ray ActorClass.options for the sending proxy actor.
-            Option details see: "https://docs.ray.io/en/latest/ray-core/api/doc/ray.actor.ActorClass.options.html". # noqa
-            Not all options can be modified, supported options are: [`resources`, `num_cpus`, 
-            `num_gpus`, `memory`, `object_store_memory`, `max_task_retries`, `max_restarts`, `_metadata`]
-        cross_silo_recv_options: A subset of Ray ActorClass.options for the receiver proxy actor.
-            Option details see: "https://docs.ray.io/en/latest/ray-core/api/doc/ray.actor.ActorClass.options.html". # noqa
-            Not all options can be modified, supported options are: [`resources`, `num_cpus`, 
-            `num_gpus`, `memory`, `object_store_memory`, `max_task_retries`, `max_restarts`, `_metadata`]
+        cross_silo_send_resource_label: Customized resource label, the SendProxyActor
+            will be scheduled based on the declared resource label. For example,
+            when setting to `{"my_label": 1}`, then the SendProxyActor will be started
+            only on Nodes with `{"resource": {"my_label": $NUM}}` where $NUM >= 1.
+        cross_silo_recv_resource_label: Customized resource label, the RecverProxyActor
+            will be scheduled based on the declared resource label. For example,
+            when setting to `{"my_label": 1}`, then the RecverProxyActor will be started
+            only on Nodes with `{"resource": {"my_label": $NUM}}` where $NUM >= 1.
         exit_on_failure_cross_silo_sending: whether exit when failure on
             cross-silo sending. If True, a SIGTERM will be signaled to self
             if failed to sending cross-silo data.
@@ -208,6 +208,8 @@ def init(
 
     logger.info(f'Started rayfed with {cluster_config}')
     set_exit_on_failure_sending(exit_on_failure_cross_silo_sending)
+    recv_actor_config = fed_config.ProxyActorConfig(
+        resource_label=cross_silo_recv_resource_label)
     # Start recv proxy
     start_recv_proxy(
         cluster=cluster,
@@ -215,15 +217,18 @@ def init(
         logging_level=logging_level,
         tls_config=tls_config,
         retry_policy=cross_silo_grpc_retry_policy,
-        actor_options=cross_silo_recv_options
+        actor_config=recv_actor_config
     )
+
+    send_actor_config = fed_config.ProxyActorConfig(
+        resource_label=cross_silo_send_resource_label)
     start_send_proxy(
         cluster=cluster,
         party=party,
         logging_level=logging_level,
         tls_config=tls_config,
         retry_policy=cross_silo_grpc_retry_policy,
-        actor_options=cross_silo_send_options
+        actor_config=send_actor_config
     )
 
     if enable_waiting_for_other_parties_ready:

--- a/fed/api.py
+++ b/fed/api.py
@@ -131,6 +131,14 @@ def init(
         cross_silo_serializing_allowed_list: The package or class list allowed for
             serializing(deserializating) cross silos. It's used for avoiding pickle
             deserializing execution attack when crossing solis.
+        cross_silo_send_options: A subset of Ray ActorClass.options for the sending proxy actor.
+            Option details see: "https://docs.ray.io/en/latest/ray-core/api/doc/ray.actor.ActorClass.options.html". # noqa
+            Not all options can be modified, supported options are: [`resources`, `num_cpus`, 
+            `num_gpus`, `memory`, `object_store_memory`, `max_task_retries`, `max_restarts`, `_metadata`]
+        cross_silo_recv_options: A subset of Ray ActorClass.options for the receiver proxy actor.
+            Option details see: "https://docs.ray.io/en/latest/ray-core/api/doc/ray.actor.ActorClass.options.html". # noqa
+            Not all options can be modified, supported options are: [`resources`, `num_cpus`, 
+            `num_gpus`, `memory`, `object_store_memory`, `max_task_retries`, `max_restarts`, `_metadata`]
         exit_on_failure_cross_silo_sending: whether exit when failure on
             cross-silo sending. If True, a SIGTERM will be signaled to self
             if failed to sending cross-silo data.

--- a/fed/api.py
+++ b/fed/api.py
@@ -41,6 +41,7 @@ def init(
     tls_config: Dict = None,
     logging_level: str = 'info',
     cross_silo_grpc_retry_policy: Dict = None,
+    cross_silo_send_max_retries: int = None,
     cross_silo_serializing_allowed_list: Dict = None,
     cross_silo_send_resource_label: Dict = None,
     cross_silo_recv_resource_label: Dict = None,
@@ -128,6 +129,7 @@ def init(
                         "UNAVAILABLE"
                     ]
                 }
+        cross_silo_send_max_retries: the max retries for sending data cross silo.
         cross_silo_serializing_allowed_list: The package or class list allowed for
             serializing(deserializating) cross silos. It's used for avoiding pickle
             deserializing execution attack when crossing solis.
@@ -228,6 +230,7 @@ def init(
         logging_level=logging_level,
         tls_config=tls_config,
         retry_policy=cross_silo_grpc_retry_policy,
+        max_retries=cross_silo_send_max_retries,
         actor_config=send_actor_config
     )
 

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -363,7 +363,7 @@ def start_recv_proxy(
     logging_level: str,
     tls_config=None,
     retry_policy=None,
-    actor_options={}
+    actor_options=None
 ):
     global _RECV_PROXY_ACTOR_NAME
 
@@ -376,8 +376,9 @@ def start_recv_proxy(
         listen_addr = party_addr['address']
 
     # Overide the default options
-    actor_options = {**_DEFAULT_RECV_PROXY_OPTIONS, **actor_options}
-    if hasattr(actor_options, "name"):
+    actor_options = {**_DEFAULT_RECV_PROXY_OPTIONS, **actor_options} \
+        if actor_options is not None else _DEFAULT_RECV_PROXY_OPTIONS
+    if not hasattr(actor_options, "name"):
         # Assign a default name
         actor_options["name"] = f"RecverProxyActor-{party}"
     logger.debug(f"Starting RecvProxyActor with options: {actor_options}")
@@ -419,8 +420,8 @@ def start_send_proxy(
     global _SEND_PROXY_ACTOR_NAME
 
     # Overide the default options
-    actor_options = {**_DEFAULT_SEND_PROXY_OPTIONS, **actor_options}
-
+    actor_options = {**_DEFAULT_SEND_PROXY_OPTIONS, **actor_options} \
+        if actor_options is not None else _DEFAULT_SEND_PROXY_OPTIONS
     logger.debug(f"Start SendProxyActor with options: {actor_options}")
     _SEND_PROXY_ACTOR = SendProxyActor.options(**actor_options)
 

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -190,6 +190,8 @@ async def send_data_grpc(
 
 @dataclass
 class ProxyActorOptions:
+    '''A subset of Ray ActorClass.options that are expose to API users 
+    '''
     resources: dict = None
     num_cpus: float = None
     num_gpus: float = None

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -135,7 +135,6 @@ async def send_data_grpc(
 ):
     grpc_options = get_grpc_options(retry_policy=retry_policy) if \
                     grpc_options is None else fed_utils.dict2tuple(grpc_options)
-
     tls_enabled = fed_utils.tls_enabled(tls_config)
     cluster_config = fed_config.get_cluster_config()
     metadata = fed_utils.dict2tuple(metadata)
@@ -424,12 +423,18 @@ def start_send_proxy(
     logging_level: str,
     tls_config: Dict = None,
     retry_policy=None,
+    max_retries=None,
     actor_config: Optional[fed_config.ProxyActorConfig] = None
 ):
     # Create SendProxyActor
     global _SEND_PROXY_ACTOR
 
     actor_options = copy.deepcopy(_DEFAULT_SEND_PROXY_OPTIONS)
+    if max_retries is not None:
+        actor_options.update({
+            "max_task_retries": max_retries,
+            "max_restarts": 1,
+            })
     if actor_config is not None and actor_config.resource_label is not None:
         actor_options.update({"resources": actor_config.resource_label})
 

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -350,10 +350,12 @@ class RecverProxyActor:
     async def _get_grpc_options(self):
         return get_grpc_options()
 
+
 _DEFAULT_RECV_PROXY_OPTIONS = {
     "max_concurrency": 1000,
 }
 _RECV_PROXY_ACTOR_NAME = None
+
 
 def start_recv_proxy(
     cluster: str,
@@ -402,6 +404,7 @@ _DEFAULT_SEND_PROXY_OPTIONS = {
     "max_concurrency": 1000,
 }
 _SEND_PROXY_ACTOR_NAME = None
+
 
 def start_send_proxy(
     cluster: Dict,

--- a/fed/barriers.py
+++ b/fed/barriers.py
@@ -378,7 +378,7 @@ def start_recv_proxy(
     # Overide the default options
     actor_options = {**_DEFAULT_RECV_PROXY_OPTIONS, **actor_options} \
         if actor_options is not None else _DEFAULT_RECV_PROXY_OPTIONS
-    if not hasattr(actor_options, "name"):
+    if "name" not in actor_options:
         # Assign a default name
         actor_options["name"] = f"RecverProxyActor-{party}"
     logger.debug(f"Starting RecvProxyActor with options: {actor_options}")
@@ -396,7 +396,7 @@ def start_recv_proxy(
     recver_proxy_actor.run_grpc_server.remote()
     assert ray.get(recver_proxy_actor.is_ready.remote(), timeout=60)
     _RECV_PROXY_ACTOR_NAME = actor_options.get("name")
-    logger.info("RecverProxy was successfully created.")
+    logger.info(f"RecverProxy was successfully created, name: {_RECV_PROXY_ACTOR_NAME}")
 
 
 _SEND_PROXY_ACTOR = None

--- a/fed/config.py
+++ b/fed/config.py
@@ -7,6 +7,7 @@
 import fed._private.compatible_utils as compatible_utils
 import fed._private.constants as fed_constants
 import cloudpickle
+from typing import Dict, Optional
 
 
 class ClusterConfig:
@@ -77,3 +78,16 @@ def get_job_config():
         raw_dict = compatible_utils.kv.get(fed_constants.KEY_OF_JOB_CONFIG)
         _job_config = JobConfig(raw_dict)
     return _job_config
+
+
+class ProxyActorConfig:
+    """A class to store parameters used for Proxy Actor
+
+    Attributes:
+        resource_label: The customized resources for the actor. This will be
+            filled into the "resource" field of Ray ActorClass.options.
+    """
+    def __init__(
+            self,
+            resource_label: Optional[Dict[str, str]] = None) -> None:
+        self.resource_label = resource_label

--- a/tests/test_setup_proxy_actor.py
+++ b/tests/test_setup_proxy_actor.py
@@ -111,7 +111,8 @@ def test_setup_proxy_failed():
                 cluster=cluster,
                 party=party,
                 cross_silo_send_options=send_proxy_options,
-                cross_silo_recv_options=recv_proxy_options
+                cross_silo_recv_options=recv_proxy_options,
+                cross_silo_timeout_in_seconds=10
             )
 
         fed.shutdown()

--- a/tests/test_setup_proxy_actor.py
+++ b/tests/test_setup_proxy_actor.py
@@ -20,6 +20,7 @@ import fed
 import fed._private.compatible_utils as compatible_utils
 import ray
 
+
 def test_setup_proxy_success():
     def run(party):
         compatible_utils.init_ray(address='local', resources={"127.0.0.1": 2})
@@ -77,13 +78,13 @@ def test_setup_proxy_failed():
         send_proxy_options = {
             "name": "MySendProxy",
             "resources": {
-                "127.0.0.2": 1 # Insufficient resource
+                "127.0.0.2": 1  # Insufficient resource
             }
         }
         recv_proxy_options = {
             "name": f"MyRecvProxy-{party}",
             "resources": {
-                "127.0.0.2": 1 # Insufficient resource
+                "127.0.0.2": 1  # Insufficient resource
             }
         }
         with pytest.raises(ray.exceptions.GetTimeoutError):
@@ -107,6 +108,7 @@ def test_setup_proxy_failed():
     p_alice.join()
     p_bob.join()
     assert p_alice.exitcode == 0 and p_bob.exitcode == 0
+
 
 if __name__ == "__main__":
     import sys

--- a/tests/test_setup_proxy_actor.py
+++ b/tests/test_setup_proxy_actor.py
@@ -35,7 +35,7 @@ def test_setup_proxy_success():
             }
         }
         recv_proxy_options = {
-            "name": f"MyRecvProxy-{party}",
+            "name": f"MyRecverProxy-{party}",
             "resources": {
                 "127.0.0.1": 1
             }
@@ -50,8 +50,8 @@ def test_setup_proxy_success():
         assert ray.get_actor("MySendProxy") is not None
         assert fed.barriers._SEND_PROXY_ACTOR_NAME == "MySendProxy"
 
-        assert ray.get_actor(f"MyRecvProxy-{party}") is not None
-        assert fed.barriers._RECV_PROXY_ACTOR_NAME == f"MyRecvProxy-{party}"
+        assert ray.get_actor(f"MyRecverProxy-{party}") is not None
+        assert fed.barriers._RECV_PROXY_ACTOR_NAME == f"MyRecverProxy-{party}"
 
         fed.shutdown()
         ray.shutdown()

--- a/tests/test_setup_proxy_actor.py
+++ b/tests/test_setup_proxy_actor.py
@@ -1,0 +1,114 @@
+# Copyright 2023 The RayFed Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import multiprocessing
+
+import pytest
+import fed
+import fed._private.compatible_utils as compatible_utils
+import ray
+
+def test_setup_proxy_success():
+    def run(party):
+        compatible_utils.init_ray(address='local', resources={"127.0.0.1": 2})
+        cluster = {
+            'alice': {'address': '127.0.0.1:11010'},
+            'bob': {'address': '127.0.0.1:11011'},
+        }
+        send_proxy_options = {
+            "name": "MySendProxy",
+            "resources": {
+                "127.0.0.1": 1
+            }
+        }
+        recv_proxy_options = {
+            "name": f"MyRecvProxy-{party}",
+            "resources": {
+                "127.0.0.1": 1
+            }
+        }
+        fed.init(
+            cluster=cluster,
+            party=party,
+            cross_silo_send_options=send_proxy_options,
+            cross_silo_recv_options=recv_proxy_options
+        )
+
+        assert ray.get_actor("MySendProxy") is not None
+        assert fed.barriers._SEND_PROXY_ACTOR_NAME == "MySendProxy"
+
+        assert ray.get_actor(f"MyRecvProxy-{party}") is not None
+        assert fed.barriers._RECV_PROXY_ACTOR_NAME == f"MyRecvProxy-{party}"
+
+        fed.shutdown()
+        ray.shutdown()
+    p_alice = multiprocessing.Process(target=run, args=('alice',))
+    p_bob = multiprocessing.Process(target=run, args=('bob',))
+    p_alice.start()
+
+    import time
+
+    time.sleep(10)
+    p_bob.start()
+    p_alice.join()
+    p_bob.join()
+    assert p_alice.exitcode == 0 and p_bob.exitcode == 0
+
+
+def test_setup_proxy_failed():
+    def run(party):
+        compatible_utils.init_ray(address='local', resources={"127.0.0.1": 1})
+        cluster = {
+            'alice': {'address': '127.0.0.1:11010'},
+            'bob': {'address': '127.0.0.1:11011'},
+        }
+        send_proxy_options = {
+            "name": "MySendProxy",
+            "resources": {
+                "127.0.0.2": 1 # Insufficient resource
+            }
+        }
+        recv_proxy_options = {
+            "name": f"MyRecvProxy-{party}",
+            "resources": {
+                "127.0.0.2": 1 # Insufficient resource
+            }
+        }
+        with pytest.raises(ray.exceptions.GetTimeoutError):
+            fed.init(
+                cluster=cluster,
+                party=party,
+                cross_silo_send_options=send_proxy_options,
+                cross_silo_recv_options=recv_proxy_options
+            )
+
+        fed.shutdown()
+        ray.shutdown()
+    p_alice = multiprocessing.Process(target=run, args=('alice',))
+    p_bob = multiprocessing.Process(target=run, args=('bob',))
+    p_alice.start()
+
+    import time
+
+    time.sleep(10)
+    p_bob.start()
+    p_alice.join()
+    p_bob.join()
+    assert p_alice.exitcode == 0 and p_bob.exitcode == 0
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/tests/test_setup_proxy_actor.py
+++ b/tests/test_setup_proxy_actor.py
@@ -24,7 +24,7 @@ from fed.barriers import filter_supported_options
 
 def test_filter_actor_options():
     user_actor_options = {
-        "name": "MyName", # invalid
+        "name": "MyName",  # invalid
         "resources": {
             "127.0.0.1": 1
         },


### PR DESCRIPTION
This is the first step of #134 

This PR provides `cross_silo_send_resource_label` and `cross_silo_recv_resource_label` config in `fed.init` and convert them to the "resources" field of ActorClass.options.