### PR TITLE
not init kv until `fed.init` called

### DIFF
--- a/fed/_private/compatible_utils.py
+++ b/fed/_private/compatible_utils.py
@@ -162,7 +162,7 @@ def _init_internal_kv():
             response = kv_actor._ping.remote()
             ray.get(response)
         kv = ClientModeInternalKv() if is_client_mode_enabled else InternalKv()
-
+        kv.initialize()
 
 def _clear_internal_kv():
     global kv

--- a/fed/_private/compatible_utils.py
+++ b/fed/_private/compatible_utils.py
@@ -157,7 +157,8 @@ def _init_internal_kv():
     if kv is None:
         from ray._private.client_mode_hook import is_client_mode_enabled
         if is_client_mode_enabled:
-            kv_actor = ray.remote(InternalKv).options(name="_INTERNAL_KV_ACTOR").remote()
+            kv_actor = ray.remote(InternalKv) \
+                .options(name="_INTERNAL_KV_ACTOR").remote()
             response = kv_actor._ping.remote()
             ray.get(response)
         kv = ClientModeInternalKv() if is_client_mode_enabled else InternalKv()

--- a/fed/_private/compatible_utils.py
+++ b/fed/_private/compatible_utils.py
@@ -176,4 +176,5 @@ def _clear_internal_kv():
             ray.kill(_internal_kv_actor)
         kv = None
 
+
 kv = None

--- a/fed/_private/compatible_utils.py
+++ b/fed/_private/compatible_utils.py
@@ -157,12 +157,13 @@ def _init_internal_kv():
     if kv is None:
         from ray._private.client_mode_hook import is_client_mode_enabled
         if is_client_mode_enabled:
-            kv_actor = ray.remote(InternalKv) \
-                .options(name="_INTERNAL_KV_ACTOR").remote()
+            kv_actor = ray.remote(InternalKv).options(
+                name="_INTERNAL_KV_ACTOR").remote()
             response = kv_actor._ping.remote()
             ray.get(response)
         kv = ClientModeInternalKv() if is_client_mode_enabled else InternalKv()
         kv.initialize()
+
 
 def _clear_internal_kv():
     global kv

--- a/fed/_private/compatible_utils.py
+++ b/fed/_private/compatible_utils.py
@@ -18,6 +18,7 @@ import fed._private.constants as fed_constants
 
 import ray.experimental.internal_kv as ray_internal_kv
 from ray._private.gcs_utils import GcsClient
+from fed._private import constants
 
 
 def _compare_version_strings(version1, version2):
@@ -161,5 +162,17 @@ def _init_internal_kv():
             ray.get(response)
         kv = ClientModeInternalKv() if is_client_mode_enabled else InternalKv()
 
+
+def _clear_internal_kv():
+    global kv
+    if kv is not None:
+        kv.delete(constants.KEY_OF_CLUSTER_CONFIG)
+        kv.delete(constants.KEY_OF_JOB_CONFIG)
+        kv.reset()
+        from ray._private.client_mode_hook import is_client_mode_enabled
+        if is_client_mode_enabled:
+            _internal_kv_actor = ray.get_actor("_INTERNAL_KV_ACTOR")
+            ray.kill(_internal_kv_actor)
+        kv = None
 
 kv = None

--- a/fed/_private/compatible_utils.py
+++ b/fed/_private/compatible_utils.py
@@ -152,12 +152,14 @@ class ClientModeInternalKv(AbstractInternalKv):
 
 def _init_internal_kv():
     """An internal API that initialize the internal kv object."""
-    from ray._private.client_mode_hook import is_client_mode_enabled
-    if is_client_mode_enabled:
-        kv_actor = ray.remote(InternalKv).options(name="_INTERNAL_KV_ACTOR").remote()
-        response = kv_actor._ping.remote()
-        ray.get(response)
-    return ClientModeInternalKv() if is_client_mode_enabled else InternalKv()
+    global kv
+    if kv is None:
+        from ray._private.client_mode_hook import is_client_mode_enabled
+        if is_client_mode_enabled:
+            kv_actor = ray.remote(InternalKv).options(name="_INTERNAL_KV_ACTOR").remote()
+            response = kv_actor._ping.remote()
+            ray.get(response)
+        kv = ClientModeInternalKv() if is_client_mode_enabled else InternalKv()
 
 
-kv = _init_internal_kv()
+kv = None

--- a/fed/api.py
+++ b/fed/api.py
@@ -228,9 +228,7 @@ def shutdown():
     Shutdown a RayFed client.
     """
     wait_sending()
-    compatible_utils.kv.delete(constants.KEY_OF_CLUSTER_CONFIG)
-    compatible_utils.kv.delete(constants.KEY_OF_JOB_CONFIG)
-    compatible_utils.kv.reset()
+    compatible_utils._clear_internal_kv()
     clear_global_context()
     logger.info('Shutdowned rayfed.')
 

--- a/fed/api.py
+++ b/fed/api.py
@@ -169,7 +169,6 @@ def init(
         ), 'Cert or key are not in tls_config.'
     # A Ray private accessing, should be replaced in public API.
     compatible_utils._init_internal_kv()
-    compatible_utils.kv.initialize()
 
     cluster_config = {
         constants.KEY_OF_CLUSTER_ADDRESSES: cluster,

--- a/tests/test_internal_kv.py
+++ b/tests/test_internal_kv.py
@@ -16,12 +16,16 @@ def test_kv_init():
         assert compatible_utils.kv is None
         fed.init(cluster=cluster, party=party)
         assert compatible_utils.kv
-        assert compatible_utils.kv.put(b"test_key", b"test_val")
+        assert not compatible_utils.kv.put(b"test_key", b"test_val")
         assert compatible_utils.kv.get(b"test_key") == b"test_val"
 
         time.sleep(5)
         fed.shutdown()
         ray.shutdown()
+
+        assert compatible_utils.kv is None
+        with pytest.raises(ValueError):
+            ray.get_actor("_INTERNAL_KV_ACTOR")
 
     p_alice = multiprocessing.Process(target=run, args=('alice',))
     p_bob = multiprocessing.Process(target=run, args=('bob',))

--- a/tests/test_internal_kv.py
+++ b/tests/test_internal_kv.py
@@ -1,0 +1,38 @@
+import multiprocessing
+import pytest
+import ray
+import fed
+import time
+import fed._private.compatible_utils as compatible_utils
+
+
+def test_kv_init():
+    def run(party):
+        compatible_utils.init_ray("local")
+        cluster = {
+            'alice': {'address': '127.0.0.1:11010', 'listen_addr': '0.0.0.0:11010'},
+            'bob': {'address': '127.0.0.1:11011', 'listen_addr': '0.0.0.0:11011'},
+        }
+        assert compatible_utils.kv is None
+        fed.init(cluster=cluster, party=party)
+        assert compatible_utils.kv
+        assert compatible_utils.kv.put(b"test_key", b"test_val")
+        assert compatible_utils.kv.get(b"test_key") == b"test_val"
+
+        time.sleep(5)
+        fed.shutdown()
+        ray.shutdown()
+
+    p_alice = multiprocessing.Process(target=run, args=('alice',))
+    p_bob = multiprocessing.Process(target=run, args=('bob',))
+    p_alice.start()
+    p_bob.start()
+    p_alice.join()
+    p_bob.join()
+    assert p_alice.exitcode == 0 and p_bob.exitcode == 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main(["-sv", __file__]))

--- a/tests/test_internal_kv.py
+++ b/tests/test_internal_kv.py
@@ -25,6 +25,7 @@ def test_kv_init():
 
         assert compatible_utils.kv is None
         with pytest.raises(ValueError):
+            # Make sure the kv actor is non-exist no matter whether it's in client mode
             ray.get_actor("_INTERNAL_KV_ACTOR")
 
     p_alice = multiprocessing.Process(target=run, args=('alice',))

--- a/tests/test_transport_proxy.py
+++ b/tests/test_transport_proxy.py
@@ -41,6 +41,7 @@ def test_n_to_1_transport():
         constants.KEY_OF_CROSS_SILO_SERIALIZING_ALLOWED_LIST: {},
         constants.KEY_OF_CROSS_SILO_TIMEOUT_IN_SECONDS: 60,
     }
+    compatible_utils._init_internal_kv()
     compatible_utils.kv.put(constants.KEY_OF_CLUSTER_CONFIG,
                             cloudpickle.dumps(cluster_config))
 
@@ -165,6 +166,7 @@ def test_send_grpc_with_meta():
             "key": "value"
         }
     }
+    compatible_utils._init_internal_kv()
     compatible_utils.kv.put(constants.KEY_OF_CLUSTER_CONFIG,
                             cloudpickle.dumps(cluster_config))
     compatible_utils.kv.put(constants.KEY_OF_JOB_CONFIG,
@@ -203,6 +205,7 @@ def test_send_grpc_with_party_specific_meta():
             "key": "value"
         }
     }
+    compatible_utils._init_internal_kv()
     compatible_utils.kv.put(constants.KEY_OF_CLUSTER_CONFIG,
                             cloudpickle.dumps(cluster_config))
     compatible_utils.kv.put(constants.KEY_OF_JOB_CONFIG,

--- a/tests/test_transport_proxy_tls.py
+++ b/tests/test_transport_proxy_tls.py
@@ -48,6 +48,7 @@ def test_n_to_1_transport():
         constants.KEY_OF_CROSS_SILO_SERIALIZING_ALLOWED_LIST: {},
         constants.KEY_OF_CROSS_SILO_TIMEOUT_IN_SECONDS: 60,
     }
+    compatible_utils._init_internal_kv()
     compatible_utils.kv.put(constants.KEY_OF_CLUSTER_CONFIG,
                             cloudpickle.dumps(cluster_config))
 


### PR DESCRIPTION
Fed will try to init the internal_kv when importing the "compatible_utils" module.
This will cause problem in client-server mode, because the import action comes first before the call of`ray.init`, and at that time, the flag `ray._private.client_mode_hook.is_client_mode_enabled` that internal_kv relies on is not "True" as expected.

This PR fixes it by only initializing internal_kv when explicitly calling `_init_internal_kv` and only init once.