### PR TITLE
Fix race condition when cleaning up.

### DIFF
--- a/fed/cleanup.py
+++ b/fed/cleanup.py
@@ -110,12 +110,13 @@ def notify_to_exit():
 
 def wait_sending():
     global _check_send_thread
-    if _check_send_thread:
+    if _check_send_thread is not None:
         notify_to_exit()
         _check_send_thread.join()
         _check_send_thread = None
 
+    global _sending_obj_refs_q
+    if _sending_obj_refs_q is not None:
         # It's safe to reset `_sending_obj_refs_q` as another
         # thread is stoped.
-        global _sending_obj_refs_q
         _sending_obj_refs_q = None

--- a/fed/cleanup.py
+++ b/fed/cleanup.py
@@ -67,10 +67,6 @@ def _check_sending_objs():
             break
 
     logger.info('Check sending thread was exited.')
-    global _check_send_thread
-    _check_send_thread = None
-    logger.info('Clearing sending queue.')
-    _sending_obj_refs_q = None
 
 
 def _main_thread_monitor():
@@ -117,3 +113,9 @@ def wait_sending():
     if _check_send_thread:
         notify_to_exit()
         _check_send_thread.join()
+        _check_send_thread = None
+
+        # It's safe to reset `_sending_obj_refs_q` as another
+        # thread is stoped.
+        global _sending_obj_refs_q
+        _sending_obj_refs_q = None

--- a/tests/test_repeat_init.py
+++ b/tests/test_repeat_init.py
@@ -51,13 +51,6 @@ def run(party):
         assert fed.cleanup._sending_obj_refs_q is None
         compatible_utils.init_ray(address='local')
         fed.init(cluster=cluster, party=party)
-        _start_check_sending()
-        time.sleep(0.5)
-        assert fed.cleanup._sending_obj_refs_q is not None
-        push_to_sending(True)
-        # Slightly longer than the queue polling
-        time.sleep(0.6)
-        assert fed.cleanup._sending_obj_refs_q is None
 
         my1 = My.party("alice").remote()
         my2 = My.party("bob").remote()

--- a/tests/test_repeat_init.py
+++ b/tests/test_repeat_init.py
@@ -16,12 +16,9 @@
 import multiprocessing
 
 import pytest
-import time
 import fed
 import fed._private.compatible_utils as compatible_utils
 import ray
-
-from fed.cleanup import _start_check_sending, push_to_sending
 
 
 @fed.remote


### PR DESCRIPTION
`_sending_obj_refs_q` and `_check_send_thread` are race conditioned when cleaning up as described in #130
Close #130