### PR TITLE
Enhance the value error when missing a reqiured param.

### DIFF
--- a/fed/_private/fed_call_holder.py
+++ b/fed/_private/fed_call_holder.py
@@ -56,6 +56,9 @@ class FedCallHolder:
         return self
 
     def internal_remote(self, *args, **kwargs):
+        if self._node_party is None or len(self._node_party) == 0:
+            raise ValueError("You should specify a party name on the fed actor.")
+
         # Generate a new fed task id for this call.
         fed_task_id = get_global_context().next_seq_id()
         if self._party == self._node_party:

--- a/fed/_private/fed_call_holder.py
+++ b/fed/_private/fed_call_holder.py
@@ -56,7 +56,7 @@ class FedCallHolder:
         return self
 
     def internal_remote(self, *args, **kwargs):
-        if self._node_party is None or len(self._node_party) == 0:
+        if not self._node_party:
             raise ValueError("You should specify a party name on the fed actor.")
 
         # Generate a new fed task id for this call.

--- a/fed/api.py
+++ b/fed/api.py
@@ -300,9 +300,9 @@ class FedRemoteFunction:
         return self
 
     def remote(self, *args, **kwargs):
-        assert (
-            self._node_party is not None
-        ), "A fed function should be specified within a party to execute."
+        if not self._node_party:
+            raise ValueError("You should specify a party name on the fed function.")
+
         return self._fed_call_holder.internal_remote(*args, **kwargs)
 
     def _execute_impl(self, args, kwargs):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,21 +41,27 @@ def test_fed_apis():
 
 
 def test_miss_party_name_on_actor():
-    compatible_utils.init_ray(address='local')
-    cluster = {
-        'alice': {'address': '127.0.0.1:11012'},
-    }
-    fed.init(cluster=cluster, party="alice")
+    def run():
+        compatible_utils.init_ray(address='local')
+        cluster = {
+            'alice': {'address': '127.0.0.1:11012'},
+        }
+        fed.init(cluster=cluster, party="alice")
 
-    @fed.remote
-    class MyActor:
-        pass
+        @fed.remote
+        class MyActor:
+            pass
 
-    with pytest.raises(ValueError):
-        MyActor.remote()
+        with pytest.raises(ValueError):
+            MyActor.remote()
 
-    fed.shutdown()
-    ray.shutdown()
+        fed.shutdown()
+        ray.shutdown()
+
+    p_alice = multiprocessing.Process(target=run)
+    p_alice.start()
+    p_alice.join()
+    assert p_alice.exitcode == 0
 
 
 if __name__ == "__main__":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,6 +40,24 @@ def test_fed_apis():
     assert p_alice.exitcode == 0
 
 
+def test_miss_party_name_on_actor():
+    compatible_utils.init_ray(address='local')
+    cluster = {
+        'alice': {'address': '127.0.0.1:11012'},
+    }
+    fed.init(cluster=cluster, party="alice")
+
+    @fed.remote
+    class MyActor:
+        pass
+
+    with pytest.raises(ValueError):
+        MyActor.remote()
+
+    fed.shutdown()
+    ray.shutdown()
+
+
 if __name__ == "__main__":
     import sys
 

--- a/tests/test_fed_get.py
+++ b/tests/test_fed_get.py
@@ -55,7 +55,7 @@ def run(party):
     fed.init(cluster=cluster, party=party)
 
     epochs = 3
-    alice_model = MyModel.remote("alice", 2)
+    alice_model = MyModel.party("alice").remote("alice", 2)
     bob_model = MyModel.party("bob").remote("bob", 4)
 
     all_mean_weights = []

--- a/tests/test_fed_get.py
+++ b/tests/test_fed_get.py
@@ -55,7 +55,7 @@ def run(party):
     fed.init(cluster=cluster, party=party)
 
     epochs = 3
-    alice_model = MyModel.party("alice").remote("alice", 2)
+    alice_model = MyModel.remote("alice", 2)
     bob_model = MyModel.party("bob").remote("bob", 4)
 
     all_mean_weights = []


### PR DESCRIPTION
Before this PR, if you miss the `party` on creating a fed actor, the program will hang.
In this PR, we address that by raising a necessary ValueEerror.
Please see the unit test for more details.