### PR TITLE
Fix importlib.metadata error in python3.7

### DIFF
--- a/fed/_private/compatible_utils.py
+++ b/fed/_private/compatible_utils.py
@@ -23,7 +23,8 @@ from fed._private import constants
 
 def _get_package_version_string(package_name):
     """
-    This utility function can retrieve the version number of a Python library in string format, such as '4.23.4'.
+    This utility function can retrieve the version number
+     of a Python library in string format, such as '4.23.4'.
     You don't need to worry about the Python version.
     When using version 3.7 and below, it uses the built-in `pkg_resources`.
     When using Python 3.8 and above, it uses `importlib.metadata`.

--- a/fed/_private/compatible_utils.py
+++ b/fed/_private/compatible_utils.py
@@ -12,30 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import abc
 import ray
 import fed._private.constants as fed_constants
 
 import ray.experimental.internal_kv as ray_internal_kv
 from fed._private import constants
-
-
-def _get_package_version_string(package_name):
-    """
-    This utility function can retrieve the version number
-     of a Python library in string format, such as '4.23.4'.
-    You don't need to worry about the Python version.
-    When using version 3.7 and below, it uses the built-in `pkg_resources`.
-    When using Python 3.8 and above, it uses `importlib.metadata`.
-    """
-    curr_python_version = sys.version.split(" ")[0]
-    if _compare_version_strings(curr_python_version, '3.7.99'):
-        import importlib.metadata
-        return importlib.metadata.version(package_name)
-    else:
-        import pkg_resources
-        return pkg_resources.get_distribution(package_name).version
 
 
 def _compare_version_strings(version1, version2):

--- a/fed/_private/compatible_utils.py
+++ b/fed/_private/compatible_utils.py
@@ -12,12 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
 import abc
 import ray
 import fed._private.constants as fed_constants
 
 import ray.experimental.internal_kv as ray_internal_kv
 from fed._private import constants
+
+
+def _get_package_version_string(package_name):
+    """
+    This utility function can retrieve the version number of a Python library in string format, such as '4.23.4'.
+    You don't need to worry about the Python version.
+    When using version 3.7 and below, it uses the built-in `pkg_resources`.
+    When using Python 3.8 and above, it uses `importlib.metadata`.
+    """
+    curr_python_version = sys.version.split(" ")[0]
+    if _compare_version_strings(curr_python_version, '3.7.99'):
+        import importlib.metadata
+        return importlib.metadata.version(package_name)
+    else:
+        import pkg_resources
+        return pkg_resources.get_distribution(package_name).version
 
 
 def _compare_version_strings(version1, version2):

--- a/fed/proxy/barriers.py
+++ b/fed/proxy/barriers.py
@@ -30,7 +30,7 @@ from fed._private.grpc_options import get_grpc_options, set_max_message_length
 import fed._private.compatible_utils as compatible_utils
 from fed.config import get_cluster_config
 if compatible_utils._compare_version_strings(
-        compatible_utils._get_package_version_string('protobuf'), '4.0.0'):
+        fed_utils.get_package_version_string('protobuf'), '4.0.0'):
     from fed.grpc import fed_pb2_in_protobuf4 as fed_pb2
     from fed.grpc import fed_pb2_grpc_in_protobuf4 as fed_pb2_grpc
 else:

--- a/fed/proxy/barriers.py
+++ b/fed/proxy/barriers.py
@@ -30,7 +30,7 @@ from fed._private.grpc_options import get_grpc_options, set_max_message_length
 import fed._private.compatible_utils as compatible_utils
 from fed.config import get_cluster_config
 if compatible_utils._compare_version_strings(
-        fed_utils.get_package_version_string('protobuf'), '4.0.0'):
+        fed_utils.get_package_version('protobuf'), '4.0.0'):
     from fed.grpc import fed_pb2_in_protobuf4 as fed_pb2
     from fed.grpc import fed_pb2_grpc_in_protobuf4 as fed_pb2_grpc
 else:

--- a/fed/proxy/barriers.py
+++ b/fed/proxy/barriers.py
@@ -17,7 +17,6 @@ import logging
 import threading
 import time
 import copy
-import importlib.metadata
 from typing import Dict, Optional
 
 import cloudpickle
@@ -28,9 +27,10 @@ import fed.config as fed_config
 import fed.utils as fed_utils
 from fed._private import constants
 from fed._private.grpc_options import get_grpc_options, set_max_message_length
-from fed._private.compatible_utils import _compare_version_strings
+import fed._private.compatible_utils as compatible_utils
 from fed.config import get_cluster_config
-if _compare_version_strings(importlib.metadata.version('protobuf'), '4.0.0'):
+if compatible_utils._compare_version_strings(
+        compatible_utils._get_package_version_string('protobuf'), '4.0.0'):
     from fed.grpc import fed_pb2_in_protobuf4 as fed_pb2
     from fed.grpc import fed_pb2_grpc_in_protobuf4 as fed_pb2_grpc
 else:

--- a/fed/utils.py
+++ b/fed/utils.py
@@ -25,7 +25,7 @@ from fed.fed_object import FedObject
 logger = logging.getLogger(__name__)
 
 
-def get_package_version_string(package_name: str) -> str:
+def get_package_version(package_name: str) -> str:
     """
     This utility function can retrieve the version number
      of a Python library in string format, such as '4.23.4'.

--- a/fed/utils.py
+++ b/fed/utils.py
@@ -14,13 +14,32 @@
 
 import logging
 import re
+import sys
 
 import fed
 import ray
 
+from fed._private.compatible_utils import _compare_version_strings
 from fed.fed_object import FedObject
 
 logger = logging.getLogger(__name__)
+
+
+def get_package_version_string(package_name: str) -> str:
+    """
+    This utility function can retrieve the version number
+     of a Python library in string format, such as '4.23.4'.
+    You don't need to worry about the Python version.
+    When using version 3.7 and below, it uses the built-in `pkg_resources`.
+    When using Python 3.8 and above, it uses `importlib.metadata`.
+    """
+    curr_python_version = sys.version.split(" ")[0]
+    if _compare_version_strings(curr_python_version, '3.7.99'):
+        import importlib.metadata
+        return importlib.metadata.version(package_name)
+    else:
+        import pkg_resources
+        return pkg_resources.get_distribution(package_name).version
 
 
 def resolve_dependencies(current_party, current_fed_task_id, *args, **kwargs):

--- a/tests/test_transport_proxy.py
+++ b/tests/test_transport_proxy.py
@@ -18,11 +18,12 @@ import pytest
 import ray
 import grpc
 
+import fed.utils as fed_utils
 import fed._private.compatible_utils as compatible_utils
 from fed._private import constants
 from fed._private import global_context
 if compatible_utils._compare_version_strings(
-        compatible_utils._get_package_version_string('protobuf'), '4.0.0'):
+        fed_utils.get_package_version_string('protobuf'), '4.0.0'):
     from fed.grpc import fed_pb2_in_protobuf4 as fed_pb2
     from fed.grpc import fed_pb2_grpc_in_protobuf4 as fed_pb2_grpc
 else:

--- a/tests/test_transport_proxy.py
+++ b/tests/test_transport_proxy.py
@@ -17,13 +17,12 @@ import cloudpickle
 import pytest
 import ray
 import grpc
-import importlib.metadata
 
 import fed._private.compatible_utils as compatible_utils
 from fed._private import constants
 from fed._private import global_context
 if compatible_utils._compare_version_strings(
-        importlib.metadata.version('protobuf'), '4.0.0'):
+        compatible_utils._get_package_version_string('protobuf'), '4.0.0'):
     from fed.grpc import fed_pb2_in_protobuf4 as fed_pb2
     from fed.grpc import fed_pb2_grpc_in_protobuf4 as fed_pb2_grpc
 else:

--- a/tests/test_transport_proxy.py
+++ b/tests/test_transport_proxy.py
@@ -23,7 +23,7 @@ import fed._private.compatible_utils as compatible_utils
 from fed._private import constants
 from fed._private import global_context
 if compatible_utils._compare_version_strings(
-        fed_utils.get_package_version_string('protobuf'), '4.0.0'):
+        fed_utils.get_package_version('protobuf'), '4.0.0'):
     from fed.grpc import fed_pb2_in_protobuf4 as fed_pb2
     from fed.grpc import fed_pb2_grpc_in_protobuf4 as fed_pb2_grpc
 else:


### PR DESCRIPTION
Turns out importlib.metadata is a standard library in Python 3.8 and later, making it incompatible for py37