### PR TITLE
feat: use `Anonymous_job` as default job name.

### DIFF
--- a/fed/_private/constants.py
+++ b/fed/_private/constants.py
@@ -27,12 +27,12 @@ KEY_OF_TLS_CONFIG = "TLS_CONFIG"
 
 KEY_OF_CROSS_SILO_COMM_CONFIG_DICT = "CROSS_SILO_COMM_CONFIG_DICT"
 
-RAYFED_LOG_FMT = "%(asctime)s %(levelname)s %(filename)s:%(lineno)s [%(party)s] -- [%(jobname)s] %(message)s" # noqa
+RAYFED_LOG_FMT = "%(asctime)s.%(msecs)03d %(levelname)s %(filename)s:%(lineno)s [%(party)s] -- [%(jobname)s] %(message)s" # noqa
 
 RAYFED_DATE_FMT = "%Y-%m-%d %H:%M:%S"
 
 RAY_VERSION_2_0_0_STR = "2.0.0"
 
-RAYFED_DEFAULT_JOB_NAME = "Anonymous"
+RAYFED_DEFAULT_JOB_NAME = "Anonymous_job"
 
 RAYFED_JOB_KV_DATA_KEY_FMT = "RAYFED#{}#{}"


### PR DESCRIPTION
`Anonymous` is confusing somehow as the default job name. Give it an explicit name.

### Before
```
2023-12-11 12:29:32 INFO barriers.py:295 [bob] -- [Anonymous] SenderProxyActor has successfully created.
```

### After
```
2023-12-11 12:29:32.598 INFO barriers.py:295 [bob] -- [Anonymous_job] SenderProxyActor has successfully created.
```