### PR TITLE
Feat: bump ray to latest 5 versions.

### DIFF
--- a/.github/workflows/unit_tests_on_ray_matrix.yml
+++ b/.github/workflows/unit_tests_on_ray_matrix.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ray_version: [2.4.0, 2.5.1, 2.6.3, 2.7.1, 2.8.1, 2.9.0]
+        ray_version: [2.31.0, 2.32.0, 2.33.0, 2.34.0, 2.35.0]
 
     timeout-minutes: 60
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -35,10 +35,11 @@ The code view in each party is exactly the same, but the execution differs based
 
 
 ## Supported Ray Versions
-| RayFed Versions | ray-1.13.0 | ray-2.4.0 | ray-2.5.1 | ray-2.6.3 | ray-2.7.1 | ray-2.8.1 | ray-2.9.0 |
-|:---------------:|:--------:|:--------:|:--------:|:--------:|:--------:|:--------:|:--------:|
-| 0.1.0           |✅         | ✅       | ✅       | ✅       | ✅        | ✅       | ✅       |
-| 0.2.0           |not released|not released|not released|not released|not released|not released|not released|
+Due to Ray's aggressive release strategy, Rayfed only supports the last 5 Ray versions.
+| RayFed Versions | ray-1.13.0 | ray-2.31.0 | ray-2.32.0 | ray-2.33.0 | ray-2.34.0 | ray-2.35.0 |
+|:---------------:|:--------:|:--------:|:--------:|:--------:|:--------:|:--------:|
+| 0.1.0           |✅         | ✅       | ✅       | ✅       | ✅        | ✅       |
+| 0.2.0           |not released|not released|not released|not released|not released|not released|
 
 
 ## Installation


### PR DESCRIPTION
Due to Ray's aggressive release strategy, let us only support the last 5 Ray versions.