### PR TITLE
Fix: make ci happy with python3.10 x ubuntu-22.04.

### DIFF
--- a/.github/workflows/building-wheels.yml
+++ b/.github/workflows/building-wheels.yml
@@ -9,8 +9,8 @@ on:
 jobs:
   build-wheels:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
-    container: docker.io/library/ubuntu:latest
+    runs-on: ubuntu-22.04
+    container: docker.io/library/ubuntu:22.04
 
     steps:
     - uses: actions/checkout@v2
@@ -18,7 +18,7 @@ jobs:
     - name: Install bazel
       run:  |
             apt-get update
-            apt-get install -yq wget gcc g++ python3.9 zlib1g-dev zip libuv1.dev
+            apt-get install -yq wget gcc g++ python3.10 zlib1g-dev zip libuv1.dev
             apt-get install -yq pip
 
     - name: Install dependencies

--- a/.github/workflows/building-wheels.yml
+++ b/.github/workflows/building-wheels.yml
@@ -27,6 +27,8 @@ jobs:
             python3 -m virtualenv -p python3 py3
             . py3/bin/activate
             which python
+            # Revert setuptools for compatibility with ray dashboard.
+            pip install setuptools==69.5.1
             pip install pytest torch cloudpickle cryptography
             pip install ray==2.0.0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,8 +9,8 @@ on:
 jobs:
   lint:
     timeout-minutes: 10 # Lint should be done in 10 minutes.
-    runs-on: ubuntu-latest
-    container: docker.io/library/ubuntu:latest
+    runs-on: ubuntu-22.04
+    container: docker.io/library/ubuntu:22.04
 
     steps:
     - uses: actions/checkout@v2
@@ -18,7 +18,7 @@ jobs:
     - name: Install bazel
       run:  |
             apt-get update
-            apt-get install -yq wget gcc g++ python3.9 zlib1g-dev zip libuv1.dev
+            apt-get install -yq wget gcc g++ python3.10 zlib1g-dev zip libuv1.dev
             apt-get install -yq pip
 
     - name: Install dependencies

--- a/.github/workflows/pypi-nightly.yml
+++ b/.github/workflows/pypi-nightly.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9
+        python-version: 3.10
 
     - name: days since the commit date
       run: |

--- a/.github/workflows/test_on_ray1.13.0.yml
+++ b/.github/workflows/test_on_ray1.13.0.yml
@@ -9,8 +9,8 @@ on:
 jobs:
   run-unit-tests:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
-    container: docker.io/library/ubuntu:latest
+    runs-on: ubuntu-22.04
+    container: docker.io/library/ubuntu:22.04
 
     steps:
     - uses: actions/checkout@v2
@@ -18,7 +18,7 @@ jobs:
     - name: Install bazel
       run:  |
             apt-get update
-            apt-get install -yq wget gcc g++ python3.9 zlib1g-dev zip libuv1.dev
+            apt-get install -yq wget gcc g++ python3.10 zlib1g-dev zip libuv1.dev
             apt-get install -yq pip
 
     - name: Install dependencies

--- a/.github/workflows/test_on_ray1.13.0.yml
+++ b/.github/workflows/test_on_ray1.13.0.yml
@@ -27,6 +27,8 @@ jobs:
             python3 -m virtualenv -p python3 py3
             . py3/bin/activate
             which python
+            # Revert setuptools for compatibility with ray dashboard.
+            pip install setuptools==69.5.1
             pip install pytest torch cloudpickle cryptography
             pip install ray==1.13.0
 

--- a/.github/workflows/unit_tests_for_protobuf_matrix.yml
+++ b/.github/workflows/unit_tests_for_protobuf_matrix.yml
@@ -31,6 +31,8 @@ jobs:
             python3 -m virtualenv -p python3 py3
             . py3/bin/activate
             which python
+            # Revert setuptools for compatibility with ray dashboard.
+            pip install setuptools==69.5.1
             pip install pytest torch cloudpickle cryptography numpy
             pip install protobuf==${{ matrix.protobuf_ver }}
             pip install ray==2.4.0

--- a/.github/workflows/unit_tests_for_protobuf_matrix.yml
+++ b/.github/workflows/unit_tests_for_protobuf_matrix.yml
@@ -13,8 +13,8 @@ jobs:
           protobuf_ver: ["3.19", "3.20", "4.23"]
 
     timeout-minutes: 60
-    runs-on: ubuntu-latest
-    container: docker.io/library/ubuntu:latest
+    runs-on: ubuntu-22.04
+    container: docker.io/library/ubuntu:22.04
 
     steps:
     - uses: actions/checkout@v2
@@ -22,7 +22,7 @@ jobs:
     - name: Install basic dependencies
       run:  |
             apt-get update
-            apt-get install -yq wget gcc g++ python3.9 zlib1g-dev zip libuv1.dev
+            apt-get install -yq wget gcc g++ python3.10 zlib1g-dev zip libuv1.dev
             apt-get install -yq pip
 
     - name: Install python dependencies

--- a/.github/workflows/unit_tests_on_ray_matrix.yml
+++ b/.github/workflows/unit_tests_on_ray_matrix.yml
@@ -14,8 +14,8 @@ jobs:
         ray_version: [2.4.0, 2.5.1, 2.6.3, 2.7.1, 2.8.1, 2.9.0]
 
     timeout-minutes: 60
-    runs-on: ubuntu-latest
-    container: docker.io/library/ubuntu:latest
+    runs-on: ubuntu-22.04
+    container: docker.io/library/ubuntu:22.04
 
     steps:
     - uses: actions/checkout@v2
@@ -23,7 +23,7 @@ jobs:
     - name: Install basic dependencies
       run:  |
             apt-get update
-            apt-get install -yq wget gcc g++ python3.9 zlib1g-dev zip libuv1.dev
+            apt-get install -yq wget gcc g++ python3.10 zlib1g-dev zip libuv1.dev
             apt-get install -yq pip
 
     - name: Install python dependencies

--- a/.github/workflows/unit_tests_on_ray_matrix.yml
+++ b/.github/workflows/unit_tests_on_ray_matrix.yml
@@ -32,6 +32,8 @@ jobs:
             python3 -m virtualenv -p python3 py3
             . py3/bin/activate
             which python
+            # Revert setuptools for compatibility with ray dashboard.
+            pip install setuptools==69.5.1
             pip install pytest
             pip install -r dev-requirements.txt
             pip install ray==${{ matrix.ray_version }}

--- a/fed/tests/serializations_tests/test_unpickle_with_whitelist.py
+++ b/fed/tests/serializations_tests/test_unpickle_with_whitelist.py
@@ -47,7 +47,7 @@ def run(party):
         'bob': '127.0.0.1:11356',
     }
     allowed_list = {
-        "numpy.core.numeric": ["*"],
+        "numpy._core.numeric": ["*"],
         "numpy": ["dtype"],
     }
     fed.init(


### PR DESCRIPTION
Since python 3.9/3.10/3.11 is not available on ubuntu latest, let us use py3.10 with ubuntu-22.04 in CI.